### PR TITLE
Add support for dispatching collection modules

### DIFF
--- a/pytest_ansible/module_dispatcher/__init__.py
+++ b/pytest_ansible/module_dispatcher/__init__.py
@@ -29,13 +29,24 @@ class BaseModuleDispatcher(object):
 
         Raise `AnsibleModuleError` when no such module exists.
         """
-        if not self.has_module(name):
-            # TODO: should we just raise an AttributeError, or a more
-            # raise AttributeError("'{0}' object has no attribute '{1}'".format(self.__class__.__name__, name))
-            raise AnsibleModuleError("The module {0} was not found in configured module paths.".format(name))
-        else:
-            self.options['module_name'] = name
-            return self._run
+        class Module:
+            """Accumulates and dispatches dot notation module names"""
+            def __init__(self, dispatcher, name):
+                self._dispatcher = dispatcher
+                self._name = [name]
+            def __getattr__(self, name):
+                self._name.append(name)
+                return self       
+            def __call__(self, *args, **kwds):
+                name = '.'.join(self._name)
+                if not self._dispatcher.has_module(name):
+                    # TODO: should we just raise an AttributeError, or a more
+                    # raise AttributeError("'{0}' object has no attribute '{1}'".format(self.__class__.__name__, name))
+                    raise AnsibleModuleError("The module {0} was not found in configured module paths.".format(name))
+                else:
+                    self._dispatcher.options['module_name'] = name
+                    return self._dispatcher._run(*args, **kwds)
+        return Module(self, name)
 
     def check_required_kwargs(self, **kwargs):
         """Raise a TypeError if any required kwargs are missing."""


### PR DESCRIPTION
Hey there, 

I've added support for calling collection modules for example `localhost.community.crypto.get_certificate`. As `__getattr__` does not handle dot notation names, I have added a small accumulator that will get the full collection module name and invoke the dispatcher when called. Have also added a basic test which validates at least the dispatching works.