### PR TITLE
Enable `isort` via `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,11 @@ repos:
   - repo: meta
     hooks:
       - id: check-useless-excludes
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: Sort import statements using isort
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,17 @@ documentation = "https://github.com/ansible-community/pytest-ansible"
 repository = "https://github.com/ansible-community/pytest-ansible"
 changelog = "https://github.com/ansible-community/pytest-ansible/releases"
 
+
+[tool.isort]
+force_single_line = true # Force from .. import to be 1 per line, minimizing changes at time of implementation
+known_first_party = ["pytest_ansible"]
+lines_after_imports = 2 # Ensures consistency for cases when there's variable vs function/class definitions after imports
+lines_between_types = 1 # Separate import/from with 1 line
+no_lines_before = "LOCALFOLDER" # Keeps local imports bundled with first-party
+profile = "black" # Avoid conflict with black
+skip_glob = []
+
+
 [tool.mypy]
 python_version = 3.9
 # strict = true
@@ -100,7 +111,6 @@ disable = [
   "too-many-statements",
   "undefined-loop-variable",
   "unexpected-keyword-arg",
-  "ungrouped-imports",
   "unnecessary-comprehension",
   "unnecessary-pass",
   "unused-argument",

--- a/src/pytest_ansible/has_version.py
+++ b/src/pytest_ansible/has_version.py
@@ -1,5 +1,7 @@
 import ansible
+
 from pkg_resources import parse_version
+
 
 has_ansible_v1 = parse_version(ansible.__version__) < parse_version("2.0.0")
 has_ansible_v2 = parse_version(ansible.__version__) >= parse_version("2.0.0")

--- a/src/pytest_ansible/host_manager/__init__.py
+++ b/src/pytest_ansible/host_manager/__init__.py
@@ -2,14 +2,12 @@
 
 import ansible
 
-from pytest_ansible.has_version import (
-    has_ansible_v2,
-    has_ansible_v24,
-    has_ansible_v28,
-    has_ansible_v29,
-    has_ansible_v212,
-    has_ansible_v213,
-)
+from pytest_ansible.has_version import has_ansible_v2
+from pytest_ansible.has_version import has_ansible_v24
+from pytest_ansible.has_version import has_ansible_v28
+from pytest_ansible.has_version import has_ansible_v29
+from pytest_ansible.has_version import has_ansible_v212
+from pytest_ansible.has_version import has_ansible_v213
 
 
 class BaseHostManager(object):

--- a/src/pytest_ansible/host_manager/v1.py
+++ b/src/pytest_ansible/host_manager/v1.py
@@ -1,4 +1,5 @@
 from ansible.inventory import Inventory
+
 from pytest_ansible.host_manager import BaseHostManager
 from pytest_ansible.module_dispatcher.v1 import ModuleDispatcherV1
 

--- a/src/pytest_ansible/host_manager/v2.py
+++ b/src/pytest_ansible/host_manager/v2.py
@@ -1,8 +1,9 @@
+from ansible.inventory import Inventory
 from ansible.parsing.dataloader import DataLoader
+from ansible.vars import VariableManager
+
 from pytest_ansible.host_manager import BaseHostManager
 from pytest_ansible.module_dispatcher.v2 import ModuleDispatcherV2
-from ansible.vars import VariableManager
-from ansible.inventory import Inventory
 
 
 class HostManagerV2(BaseHostManager):

--- a/src/pytest_ansible/host_manager/v212.py
+++ b/src/pytest_ansible/host_manager/v212.py
@@ -1,8 +1,9 @@
+from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
+from ansible.vars.manager import VariableManager
+
 from pytest_ansible.host_manager import BaseHostManager
 from pytest_ansible.module_dispatcher.v212 import ModuleDispatcherV212
-from ansible.vars.manager import VariableManager
-from ansible.inventory.manager import InventoryManager
 
 
 class HostManagerV212(BaseHostManager):

--- a/src/pytest_ansible/host_manager/v213.py
+++ b/src/pytest_ansible/host_manager/v213.py
@@ -1,8 +1,9 @@
+from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
+from ansible.vars.manager import VariableManager
+
 from pytest_ansible.host_manager import BaseHostManager
 from pytest_ansible.module_dispatcher.v213 import ModuleDispatcherV213
-from ansible.vars.manager import VariableManager
-from ansible.inventory.manager import InventoryManager
 
 
 class HostManagerV213(BaseHostManager):

--- a/src/pytest_ansible/host_manager/v24.py
+++ b/src/pytest_ansible/host_manager/v24.py
@@ -1,8 +1,9 @@
+from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
+from ansible.vars.manager import VariableManager
+
 from pytest_ansible.host_manager import BaseHostManager
 from pytest_ansible.module_dispatcher.v24 import ModuleDispatcherV24
-from ansible.vars.manager import VariableManager
-from ansible.inventory.manager import InventoryManager
 
 
 class HostManagerV24(BaseHostManager):

--- a/src/pytest_ansible/host_manager/v28.py
+++ b/src/pytest_ansible/host_manager/v28.py
@@ -1,8 +1,9 @@
+from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
+from ansible.vars.manager import VariableManager
+
 from pytest_ansible.host_manager import BaseHostManager
 from pytest_ansible.module_dispatcher.v28 import ModuleDispatcherV28
-from ansible.vars.manager import VariableManager
-from ansible.inventory.manager import InventoryManager
 
 
 class HostManagerV28(BaseHostManager):

--- a/src/pytest_ansible/host_manager/v29.py
+++ b/src/pytest_ansible/host_manager/v29.py
@@ -1,8 +1,9 @@
+from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
+from ansible.vars.manager import VariableManager
+
 from pytest_ansible.host_manager import BaseHostManager
 from pytest_ansible.module_dispatcher.v29 import ModuleDispatcherV29
-from ansible.vars.manager import VariableManager
-from ansible.inventory.manager import InventoryManager
 
 
 class HostManagerV29(BaseHostManager):

--- a/src/pytest_ansible/module_dispatcher/__init__.py
+++ b/src/pytest_ansible/module_dispatcher/__init__.py
@@ -1,6 +1,7 @@
 """Define BaseModuleDispatcher class."""
 
 from typing import Sequence
+
 from pytest_ansible.errors import AnsibleModuleError
 
 

--- a/src/pytest_ansible/module_dispatcher/v1.py
+++ b/src/pytest_ansible/module_dispatcher/v1.py
@@ -1,14 +1,16 @@
 import warnings
+
 import ansible
 import ansible.constants
-import ansible.utils
 import ansible.errors
+import ansible.utils
 
 from ansible.runner import Runner
-from pytest_ansible.module_dispatcher import BaseModuleDispatcher
+
 from pytest_ansible.errors import AnsibleConnectionFailure
-from pytest_ansible.results import AdHocResult
 from pytest_ansible.has_version import has_ansible_v1
+from pytest_ansible.module_dispatcher import BaseModuleDispatcher
+from pytest_ansible.results import AdHocResult
 
 
 if not has_ansible_v1:

--- a/src/pytest_ansible/module_dispatcher/v2.py
+++ b/src/pytest_ansible/module_dispatcher/v2.py
@@ -1,20 +1,25 @@
 from __future__ import annotations
-from typing import Any, Sequence
-import warnings
-import ansible.constants
-import ansible.utils
-import ansible.errors
 
-from ansible.plugins.callback import CallbackBase
-from ansible.executor.task_queue_manager import TaskQueueManager
-from ansible.playbook.play import Play
+import warnings
+
+from typing import Any
+from typing import Sequence
+
+import ansible.constants
+import ansible.errors
+import ansible.utils
 
 # from ansible.plugins.loader import module_loader
 from ansible.cli import CLI
-from pytest_ansible.module_dispatcher import BaseModuleDispatcher
-from pytest_ansible.results import AdHocResult
+from ansible.executor.task_queue_manager import TaskQueueManager
+from ansible.playbook.play import Play
+from ansible.plugins.callback import CallbackBase
+
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v2
+from pytest_ansible.module_dispatcher import BaseModuleDispatcher
+from pytest_ansible.results import AdHocResult
+
 
 if not has_ansible_v2:
     raise ImportError("Only supported with ansible-2.* and newer")

--- a/src/pytest_ansible/module_dispatcher/v212.py
+++ b/src/pytest_ansible/module_dispatcher/v212.py
@@ -1,25 +1,31 @@
 from __future__ import annotations
+
 import sys
+import warnings
+
 from typing import Sequence
 
-import warnings
 import ansible.constants
-import ansible.utils
 import ansible.errors
+import ansible.utils
 
-from ansible.plugins.callback import CallbackBase
+from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
-from ansible.cli.adhoc import AdHocCLI
-from pytest_ansible.module_dispatcher.v2 import ModuleDispatcherV2
-from pytest_ansible.results import AdHocResult
+from ansible.plugins.callback import CallbackBase
+
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v212
+from pytest_ansible.module_dispatcher.v2 import ModuleDispatcherV2
+from pytest_ansible.results import AdHocResult
 
+
+# pylint: disable=ungrouped-imports
 if not has_ansible_v212:
     raise ImportError("Only supported with ansible-2.12 and newer")
 else:
     from ansible.plugins.loader import module_loader
+# pylint: enable=ungrouped-imports
 
 
 class ResultAccumulator(CallbackBase):

--- a/src/pytest_ansible/module_dispatcher/v213.py
+++ b/src/pytest_ansible/module_dispatcher/v213.py
@@ -1,23 +1,29 @@
 import sys
-
 import warnings
-import ansible.constants
-import ansible.utils
-import ansible.errors
 
-from ansible.plugins.callback import CallbackBase
+import ansible.constants
+import ansible.errors
+import ansible.utils
+
+from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
-from ansible.cli.adhoc import AdHocCLI
-from pytest_ansible.module_dispatcher.v2 import ModuleDispatcherV2
-from pytest_ansible.results import AdHocResult
+from ansible.plugins.callback import CallbackBase
+
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v213
+from pytest_ansible.module_dispatcher.v2 import ModuleDispatcherV2
+from pytest_ansible.results import AdHocResult
+
+
+# pylint: disable=ungrouped-imports
 
 if not has_ansible_v213:
     raise ImportError("Only supported with ansible-2.13 and newer")
 else:
     from ansible.plugins.loader import module_loader
+
+# pylint: enable=ungrouped-imports
 
 
 class ResultAccumulator(CallbackBase):

--- a/src/pytest_ansible/module_dispatcher/v24.py
+++ b/src/pytest_ansible/module_dispatcher/v24.py
@@ -1,23 +1,28 @@
 import warnings
-import ansible.constants
-import ansible.utils
-import ansible.errors
 
-from ansible.plugins.callback import CallbackBase
+import ansible.constants
+import ansible.errors
+import ansible.utils
+
+from ansible.cli import CLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
-from ansible.cli import CLI
+from ansible.plugins.callback import CallbackBase
+
+from pytest_ansible.errors import AnsibleConnectionFailure
+from pytest_ansible.has_version import has_ansible_v24
 from pytest_ansible.module_dispatcher.v2 import ModuleDispatcherV2
 from pytest_ansible.results import AdHocResult
-from pytest_ansible.errors import AnsibleConnectionFailure
-from pytest_ansible.has_version import (
-    has_ansible_v24,
-)
+
+
+# pylint: disable=ungrouped-imports
 
 if not has_ansible_v24:
     raise ImportError("Only supported with ansible-2.4 and newer")
 else:
     from ansible.plugins.loader import module_loader
+
+# pylint: enable=ungrouped-imports
 
 
 class ResultAccumulator(CallbackBase):

--- a/src/pytest_ansible/module_dispatcher/v28.py
+++ b/src/pytest_ansible/module_dispatcher/v28.py
@@ -1,23 +1,30 @@
 import sys
-
 import warnings
-import ansible.constants
-import ansible.utils
-import ansible.errors
 
-from ansible.plugins.callback import CallbackBase
+import ansible.constants
+import ansible.errors
+import ansible.utils
+
+from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
-from ansible.cli.adhoc import AdHocCLI
-from pytest_ansible.module_dispatcher.v2 import ModuleDispatcherV2
-from pytest_ansible.results import AdHocResult
+from ansible.plugins.callback import CallbackBase
+
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v28
+from pytest_ansible.module_dispatcher.v2 import ModuleDispatcherV2
+from pytest_ansible.results import AdHocResult
+
+
+# pylint: disable=ungrouped-imports
+
 
 if not has_ansible_v28:
     raise ImportError("Only supported with ansible-2.8 and newer")
 else:
     from ansible.plugins.loader import module_loader
+
+# pylint: enable=ungrouped-imports
 
 
 class ResultAccumulator(CallbackBase):

--- a/src/pytest_ansible/module_dispatcher/v29.py
+++ b/src/pytest_ansible/module_dispatcher/v29.py
@@ -1,23 +1,29 @@
 import sys
-
 import warnings
-import ansible.constants
-import ansible.utils
-import ansible.errors
 
-from ansible.plugins.callback import CallbackBase
+import ansible.constants
+import ansible.errors
+import ansible.utils
+
+from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
-from ansible.cli.adhoc import AdHocCLI
-from pytest_ansible.module_dispatcher.v2 import ModuleDispatcherV2
-from pytest_ansible.results import AdHocResult
+from ansible.plugins.callback import CallbackBase
+
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v29
+from pytest_ansible.module_dispatcher.v2 import ModuleDispatcherV2
+from pytest_ansible.results import AdHocResult
+
+
+# pylint: disable=ungrouped-imports
 
 if not has_ansible_v29:
     raise ImportError("Only supported with ansible-2.9 and newer")
 else:
     from ansible.plugins.loader import module_loader
+
+# pylint: enable=ungrouped-imports
 
 
 class ResultAccumulator(CallbackBase):

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -1,19 +1,17 @@
 """PyTest Ansible Plugin."""
 
-import pytest
 import ansible
 import ansible.constants
-import ansible.utils
 import ansible.errors
+import ansible.utils
+import pytest
 
 from ansible.plugins.loader import become_loader
 
-from pytest_ansible.fixtures import (
-    ansible_adhoc,
-    ansible_module,
-    ansible_facts,
-    localhost,
-)
+from pytest_ansible.fixtures import ansible_adhoc
+from pytest_ansible.fixtures import ansible_facts
+from pytest_ansible.fixtures import ansible_module
+from pytest_ansible.fixtures import localhost
 from pytest_ansible.host_manager import get_host_manager
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 import pytest
-from pytest_ansible.has_version import (
-    has_ansible_v1,
-    has_ansible_v24,
-)
+
+from pytest_ansible.has_version import has_ansible_v1
+from pytest_ansible.has_version import has_ansible_v24
+
 
 try:
     from ansible.utils import context_objects as co

--- a/tests/test_adhoc.py
+++ b/tests/test_adhoc.py
@@ -1,13 +1,20 @@
 import pytest
 
-from _pytest.main import ExitCode
 
+try:
+    from _pytest.main import EXIT_INTERRUPTED  # type: ignore[attr-defined]
+    from _pytest.main import EXIT_NOTESTSCOLLECTED  # type: ignore[attr-defined]
+    from _pytest.main import EXIT_OK  # type: ignore[attr-defined]
+    from _pytest.main import EXIT_TESTSFAILED  # type: ignore[attr-defined]
+    from _pytest.main import EXIT_USAGEERROR  # type: ignore[attr-defined]
+except ImportError:
+    from _pytest.main import ExitCode
 
-EXIT_OK = ExitCode.OK
-EXIT_TESTSFAILED = ExitCode.TESTS_FAILED
-EXIT_USAGEERROR = ExitCode.USAGE_ERROR
-EXIT_INTERRUPTED = ExitCode.INTERRUPTED
-EXIT_NOTESTSCOLLECTED = ExitCode.NO_TESTS_COLLECTED
+    EXIT_OK = ExitCode.OK
+    EXIT_TESTSFAILED = ExitCode.TESTS_FAILED
+    EXIT_USAGEERROR = ExitCode.USAGE_ERROR
+    EXIT_INTERRUPTED = ExitCode.INTERRUPTED
+    EXIT_NOTESTSCOLLECTED = ExitCode.NO_TESTS_COLLECTED
 
 
 @pytest.mark.old

--- a/tests/test_adhoc.py
+++ b/tests/test_adhoc.py
@@ -1,21 +1,13 @@
 import pytest
 
-try:
-    from _pytest.main import (  # type: ignore
-        EXIT_OK,
-        EXIT_TESTSFAILED,
-        EXIT_USAGEERROR,
-        EXIT_NOTESTSCOLLECTED,
-        EXIT_INTERRUPTED,
-    )  # NOQA
-except ImportError:
-    from _pytest.main import ExitCode
+from _pytest.main import ExitCode
 
-    EXIT_OK = ExitCode.OK
-    EXIT_TESTSFAILED = ExitCode.TESTS_FAILED
-    EXIT_USAGEERROR = ExitCode.USAGE_ERROR
-    EXIT_INTERRUPTED = ExitCode.INTERRUPTED
-    EXIT_NOTESTSCOLLECTED = ExitCode.NO_TESTS_COLLECTED
+
+EXIT_OK = ExitCode.OK
+EXIT_TESTSFAILED = ExitCode.TESTS_FAILED
+EXIT_USAGEERROR = ExitCode.USAGE_ERROR
+EXIT_INTERRUPTED = ExitCode.INTERRUPTED
+EXIT_NOTESTSCOLLECTED = ExitCode.NO_TESTS_COLLECTED
 
 
 @pytest.mark.old

--- a/tests/test_adhoc_result.py
+++ b/tests/test_adhoc_result.py
@@ -1,7 +1,11 @@
-import pytest
 from types import GeneratorType
-from pytest_ansible.results import ModuleResult
+
+import pytest
+
 from conftest import ALL_HOSTS
+
+from pytest_ansible.results import ModuleResult
+
 
 invalid_hosts = ["none", "all", "*", "local*"]
 
@@ -76,8 +80,8 @@ def test_not_getattr(adhoc_result, host_pattern):
 
 @pytest.mark.requires_ansible_v1
 def test_connection_failure_v1():
-    from pytest_ansible.host_manager import get_host_manager
     from pytest_ansible.errors import AnsibleConnectionFailure
+    from pytest_ansible.host_manager import get_host_manager
 
     hosts = get_host_manager(inventory="unknown.example.com,", connection="smart")
     with pytest.raises(AnsibleConnectionFailure) as exc_info:
@@ -100,8 +104,8 @@ def test_connection_failure_v1():
 
 @pytest.mark.requires_ansible_v2
 def test_connection_failure_v2():
-    from pytest_ansible.host_manager import get_host_manager
     from pytest_ansible.errors import AnsibleConnectionFailure
+    from pytest_ansible.host_manager import get_host_manager
 
     hosts = get_host_manager(inventory="unknown.example.com,", connection="smart")
     with pytest.raises(AnsibleConnectionFailure) as exc_info:
@@ -127,8 +131,8 @@ def test_connection_failure_v2():
 
 @pytest.mark.requires_ansible_v2
 def test_connection_failure_extra_inventory_v2():
-    from pytest_ansible.host_manager import get_host_manager
     from pytest_ansible.errors import AnsibleConnectionFailure
+    from pytest_ansible.host_manager import get_host_manager
 
     hosts = get_host_manager(
         inventory="localhost", extra_inventory="unknown.example.extra.com,"

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 try:
     from _pytest.main import EXIT_OK  # type: ignore
 except ImportError:

--- a/tests/test_host_manager.py
+++ b/tests/test_host_manager.py
@@ -1,12 +1,12 @@
 import pytest
+
 from ansible.errors import AnsibleError
-from conftest import (
-    ALL_HOSTS,
-    POSITIVE_HOST_PATTERNS,
-    NEGATIVE_HOST_PATTERNS,
-    POSITIVE_HOST_SLICES,
-    NEGATIVE_HOST_SLICES,
-)
+from conftest import ALL_HOSTS
+from conftest import NEGATIVE_HOST_PATTERNS
+from conftest import NEGATIVE_HOST_SLICES
+from conftest import POSITIVE_HOST_PATTERNS
+from conftest import POSITIVE_HOST_SLICES
+
 
 pytestmark = [
     pytest.mark.unit,

--- a/tests/test_module_dispatcher.py
+++ b/tests/test_module_dispatcher.py
@@ -1,5 +1,7 @@
 import pytest
-from conftest import POSITIVE_HOST_PATTERNS, NEGATIVE_HOST_PATTERNS
+
+from conftest import NEGATIVE_HOST_PATTERNS
+from conftest import POSITIVE_HOST_PATTERNS
 
 
 def test_runtime_error():

--- a/tests/test_module_result.py
+++ b/tests/test_module_result.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pytest_ansible.results import ModuleResult
 
 

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,20 +1,22 @@
+import re
 import sys
-import pytest
-import ansible
-from pkg_resources import parse_version
-from pytest_ansible.has_version import has_ansible_v28
 
 from unittest import mock
-import re
+
+import ansible
+import pytest
+
+from pkg_resources import parse_version
+
+from pytest_ansible.has_version import has_ansible_v28
+
 
 try:
-    from _pytest.main import (  # type: ignore
-        EXIT_OK,
-        EXIT_TESTSFAILED,
-        EXIT_USAGEERROR,
-        EXIT_NOTESTSCOLLECTED,
-        EXIT_INTERRUPTED,
-    )  # NOQA
+    from _pytest.main import EXIT_INTERRUPTED  # type: ignore[attr-defined]
+    from _pytest.main import EXIT_NOTESTSCOLLECTED  # type: ignore[attr-defined]
+    from _pytest.main import EXIT_OK  # type: ignore[attr-defined]
+    from _pytest.main import EXIT_TESTSFAILED  # type: ignore[attr-defined]
+    from _pytest.main import EXIT_USAGEERROR  # type: ignore[attr-defined]
 except ImportError:
     from _pytest.main import ExitCode
 


### PR DESCRIPTION
This enables `isort` via pre-commit and removes the `pylint` exception for ungrouped imports.

