### PR TITLE
Add `consider-using-f-string` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,6 @@ disable = [
   # https://github.com/PyCQA/pylint/issues/8453
   "preferred-module",
   # Temporarily disabled until we fix them:
-  "consider-using-f-string",
   "duplicate-code",
   "fixme",
   "implicit-str-concat",

--- a/src/pytest_ansible/host_manager/__init__.py
+++ b/src/pytest_ansible/host_manager/__init__.py
@@ -55,7 +55,7 @@ class BaseHostManager(object):
         """Raise a TypeError if any required kwargs are missing."""
         for kwarg in self._required_kwargs:
             if kwarg not in self.options:
-                raise TypeError("Missing required keyword argument '%s'" % kwarg)
+                raise TypeError(f"Missing required keyword argument '{kwarg}'")
 
     def has_matching_inventory(self, host_pattern):
         """Return whether any matching ansible inventory is found for the provided host_pattern."""
@@ -93,7 +93,7 @@ class BaseHostManager(object):
     def __getattr__(self, attr):
         """Return a ModuleDispatcher instance described the provided `attr`."""
         if not self.has_matching_inventory(attr):
-            raise AttributeError("type HostManager has no attribute '%s'" % attr)
+            raise AttributeError(f"type HostManager has no attribute '{attr}'")
         else:
             self.options["host_pattern"] = attr
             return self._dispatcher(**self.options)

--- a/src/pytest_ansible/module_dispatcher/__init__.py
+++ b/src/pytest_ansible/module_dispatcher/__init__.py
@@ -37,7 +37,7 @@ class BaseModuleDispatcher(object):
             # TODO: should we just raise an AttributeError, or a more
             # raise AttributeError("'{0}' object has no attribute '{1}'".format(self.__class__.__name__, name))
             raise AnsibleModuleError(
-                "The module {0} was not found in configured module paths.".format(name)
+                f"The module {name} was not found in configured module paths."
             )
         else:
             self.options["module_name"] = name
@@ -47,7 +47,7 @@ class BaseModuleDispatcher(object):
         """Raise a TypeError if any required kwargs are missing."""
         for kwarg in self.required_kwargs:
             if kwarg not in self.options:
-                raise TypeError("Missing required keyword argument '%s'" % kwarg)
+                raise TypeError(f"Missing required keyword argument '{kwarg}'")
 
     def has_module(self, name):
         """Return whether ansible provides the requested module."""

--- a/src/pytest_ansible/module_dispatcher/v212.py
+++ b/src/pytest_ansible/module_dispatcher/v212.py
@@ -124,9 +124,9 @@ class ModuleDispatcherV212(ModuleDispatcherV2):
                 continue
 
             if arg_value is True:
-                args.append("--{0}".format(argument))
+                args.append(f"--{argument}")
             else:
-                args.append("--{0}={1}".format(argument, arg_value))
+                args.append(f"--{argument}={arg_value}")
 
         # Use Ansible's own adhoc cli to parse the fake command line we created and then save it
         # into Ansible's global context

--- a/src/pytest_ansible/module_dispatcher/v213.py
+++ b/src/pytest_ansible/module_dispatcher/v213.py
@@ -131,9 +131,9 @@ class ModuleDispatcherV213(ModuleDispatcherV2):
                 continue
 
             if arg_value is True:
-                args.append("--{0}".format(argument))
+                args.append(f"--{argument}")
             else:
-                args.append("--{0}={1}".format(argument, arg_value))
+                args.append(f"--{argument}={arg_value}")
 
         # Use Ansible's own adhoc cli to parse the fake command line we created and then save it
         # into Ansible's global context

--- a/src/pytest_ansible/module_dispatcher/v28.py
+++ b/src/pytest_ansible/module_dispatcher/v28.py
@@ -123,9 +123,9 @@ class ModuleDispatcherV28(ModuleDispatcherV2):
                 continue
 
             if arg_value is True:
-                args.append("--{0}".format(argument))
+                args.append(f"--{argument}")
             else:
-                args.append("--{0}={1}".format(argument, arg_value))
+                args.append(f"--{argument}={arg_value}")
 
         # Use Ansible's own adhoc cli to parse the fake command line we created and then save it
         # into Ansible's global context

--- a/src/pytest_ansible/module_dispatcher/v29.py
+++ b/src/pytest_ansible/module_dispatcher/v29.py
@@ -122,9 +122,9 @@ class ModuleDispatcherV29(ModuleDispatcherV2):
                 continue
 
             if arg_value is True:
-                args.append("--{0}".format(argument))
+                args.append(f"--{argument}")
             else:
-                args.append("--{0}={1}".format(argument, arg_value))
+                args.append(f"--{argument}={arg_value}")
 
         # Use Ansible's own adhoc cli to parse the fake command line we created and then save it
         # into Ansible's global context

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -115,9 +115,9 @@ def pytest_addoption(parser):
         action="store",
         dest="ansible_become_method",
         default=ansible.constants.DEFAULT_BECOME_METHOD,
-        help="privilege escalation method to use (default: %%(default)s), valid choices: [ %s ]"
-        % (" | ".join(become_methods())),
+        help=f"privilege escalation method to use (default: %(default)s), valid choices: [ {' | '.join(become_methods())} ]",
     )
+
     group.addoption(
         "--become-user",
         "--ansible-become-user",
@@ -210,7 +210,7 @@ class PyTestAnsiblePlugin:
 
     def pytest_report_header(self, config, startdir):
         """Return the version of ansible."""
-        return "ansible: %s" % ansible.__version__
+        return f"ansible: {ansible.__version__}"
 
     def pytest_collection_modifyitems(self, session, config, items):
         """Validate --ansible-* parameters."""

--- a/src/pytest_ansible/results.py
+++ b/src/pytest_ansible/results.py
@@ -52,7 +52,7 @@ class AdHocResult(object):
         """Fixme."""
         required_kwargs = ("contacted",)
         for kwarg in required_kwargs:
-            assert kwarg in kwargs, "Missing required keyword argument '%s'" % kwarg
+            assert kwarg in kwargs, f"Missing required keyword argument '{kwarg}'"
             setattr(self, kwarg, kwargs.get(kwarg))
 
     def __getitem__(self, item):
@@ -67,7 +67,7 @@ class AdHocResult(object):
         if attr in self.contacted:
             return ModuleResult(**self.contacted[attr])
         else:
-            raise AttributeError("type AdHocResult has no attribute '%s'" % attr)
+            raise AttributeError(f"type AdHocResult has no attribute '{attr}'")
 
     def __len__(self):
         """Return the number of contacted hosts."""

--- a/tests/test_adhoc.py
+++ b/tests/test_adhoc.py
@@ -51,9 +51,9 @@ def test_contacted_with_params(testdir, option):
 @pytest.mark.old
 def test_contacted_with_params_and_inventory_marker(testdir, option):
     """FIXME"""
-    src = """
+    src = f"""
         import pytest
-        @pytest.mark.ansible(inventory='%s')
+        @pytest.mark.ansible(inventory='{option.inventory}')
         def test_func(ansible_module):
             contacted = ansible_module.ping()
 
@@ -64,9 +64,8 @@ def test_contacted_with_params_and_inventory_marker(testdir, option):
                 assert result.is_successful
                 assert result['ping'] == 'pong'
 
-    """ % str(
-        option.inventory
-    )
+        """
+
     testdir.makepyfile(src)
     result = testdir.runpytest_subprocess(
         *option.args + ["--ansible-host-pattern", "local"]
@@ -109,9 +108,9 @@ def test_contacted_with_params_and_host_pattern_marker(testdir, option):
 @pytest.mark.old
 def test_contacted_with_params_and_inventory_host_pattern_marker(testdir, option):
     """FIXME"""
-    src = """
+    src = f"""
         import pytest
-        @pytest.mark.ansible(inventory='%s', host_pattern='local')
+        @pytest.mark.ansible(inventory='{option.inventory}', host_pattern='local')
         def test_func(ansible_module):
             contacted = ansible_module.ping()
 
@@ -121,10 +120,8 @@ def test_contacted_with_params_and_inventory_host_pattern_marker(testdir, option
             for result in contacted.values():
                 assert result.is_successful
                 assert result['ping'] == 'pong'
+        """
 
-    """ % str(
-        option.inventory
-    )
     testdir.makepyfile(src)
     result = testdir.runpytest_subprocess(
         *option.args
@@ -140,14 +137,14 @@ def test_become(testdir, option):
     but verifies that 'sudo' was attempted by asserting
     '--ansible-become-user' fails as expected.
     """
-    src = """
+    src = f"""
         import pytest
         import ansible
         import re
         import os
         from pkg_resources import parse_version
 
-        @pytest.mark.ansible(inventory='%s', host_pattern='localhost')
+        @pytest.mark.ansible(inventory='{option.inventory}', host_pattern='localhost')
         def test_func(ansible_module):
             contacted = ansible_module.ping()
             # assert contacted hosts ...
@@ -167,9 +164,8 @@ def test_become(testdir, option):
                 else:
                     assert 'msg' in result, "Missing expected field in JSON response: msg"
                     assert 'sudo: unknown user: asdfasdf' in result['msg']
-    """ % str(
-        option.inventory
-    )
+        """
+
     testdir.makepyfile(src)
     result = testdir.runpytest_subprocess(
         *option.args
@@ -222,10 +218,10 @@ def test_dark_with_params(testdir, option):
 @pytest.mark.old
 def test_dark_with_params_and_inventory_marker(testdir, option):
     """FIXME"""
-    src = """
+    src = f"""
         import pytest
         from pytest_ansible.errors import (AnsibleConnectionFailure, AnsibleNoHostsMatch)
-        @pytest.mark.ansible(inventory='{inventory}')
+        @pytest.mark.ansible(inventory='{option.inventory}')
         def test_func(ansible_module):
             exc_info = pytest.raises(AnsibleConnectionFailure, ansible_module.ping)
 
@@ -235,9 +231,8 @@ def test_dark_with_params_and_inventory_marker(testdir, option):
 
             # assert dark hosts ...
             assert exc_info.value.dark
-    """.format(
-        inventory=str(option.inventory)
-    )
+        """
+
     testdir.makepyfile(src)
     result = testdir.runpytest_subprocess(
         *option.args + ["--ansible-host-pattern", "unreachable"]

--- a/tests/test_host_manager.py
+++ b/tests/test_host_manager.py
@@ -25,7 +25,7 @@ def test_keys(hosts):
 
 @pytest.mark.parametrize("host_pattern, num_hosts", POSITIVE_HOST_PATTERNS)
 def test_contains(host_pattern, num_hosts, hosts):
-    assert host_pattern in hosts, "{0} not in hosts".format(host_pattern)
+    assert host_pattern in hosts, f"{host_pattern} not in hosts"
 
 
 @pytest.mark.parametrize("host_pattern, num_hosts", NEGATIVE_HOST_PATTERNS)
@@ -51,11 +51,9 @@ def test_getattr(host_pattern, num_hosts, hosts):
 
 @pytest.mark.parametrize("host_slice, num_hosts", POSITIVE_HOST_SLICES)
 def test_slice(host_slice, num_hosts, hosts):
-    assert len(hosts[host_slice]) == num_hosts, "%s != %s for %s" % (
-        len(hosts[host_slice]),
-        num_hosts,
-        host_slice,
-    )
+    assert (
+        len(hosts[host_slice]) == num_hosts
+    ), f"{len(hosts[host_slice])} != {num_hosts} for {host_slice}"
 
 
 @pytest.mark.parametrize("host_slice", NEGATIVE_HOST_SLICES)

--- a/tests/test_module_dispatcher.py
+++ b/tests/test_module_dispatcher.py
@@ -50,8 +50,7 @@ def test_ansible_module_error(hosts):
 
     with pytest.raises(AnsibleModuleError) as exc_info:
         hosts.all.a_module_that_most_certainly_does_not_exist()
-    assert str(
-        exc_info.value
-    ) == "The module {0} was not found in configured module paths.".format(
-        "a_module_that_most_certainly_does_not_exist"
+    assert (
+        str(exc_info.value)
+        == f"The module {'a_module_that_most_certainly_does_not_exist'} was not found in configured module paths."
     )

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -73,11 +73,7 @@ def test_report_header(testdir, option):
 
     result = testdir.runpytest(*option.args)
     assert result.ret == EXIT_NOTESTSCOLLECTED
-    result.stdout.fnmatch_lines(
-        [
-            "ansible: %s" % ansible.__version__,
-        ]
-    )
+    result.stdout.fnmatch_lines([f"ansible: {ansible.__version__}"])
 
 
 def test_params_not_required_when_not_using_fixture(testdir, option):
@@ -104,13 +100,12 @@ def test_params_not_required_when_not_using_fixture(testdir, option):
 def test_params_required_when_using_fixture(testdir, option, fixture_name):
     """Verify the ansible parameters are required if the fixture is used."""
 
-    src = """
+    src = f"""
         import pytest
-        def test_func({0}):
-            {0}
-    """.format(
-        fixture_name
-    )
+        def test_func({fixture_name}):
+            {fixture_name}
+        """
+
     testdir.makepyfile(src)
     result = testdir.runpytest(*option.args)
     assert result.ret == EXIT_USAGEERROR
@@ -146,9 +141,7 @@ def test_param_requires_value(testdir, required_value_parameter):
     result = testdir.runpytest(*[required_value_parameter])
     assert result.ret == EXIT_USAGEERROR
     result.stderr.fnmatch_lines(
-        [
-            "*: error: argument *%s*: expected one argument" % required_value_parameter,
-        ]
+        [f"*: error: argument *{required_value_parameter}*: expected one argument"]
     )
 
 


### PR DESCRIPTION
The `f-string check` makes sure that we use `f-strings` instead of the traditional `string formatting` method. The traditional string formatting method involves using the `%` operator or the `.format()` method to insert values into a string. However, using f-strings can make our code more readable, especially when dealing with complex string formatting operations.

CC: @ssbarnea @cidrblock 

Related to #85 