### PR TITLE
Add `implicit-str-concat` & `missing-class-docstring` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,11 +84,9 @@ disable = [
   # Temporarily disabled until we fix them:
   "duplicate-code",
   "fixme",
-  "implicit-str-concat",
   "import-error",
   "import-outside-toplevel",
   "invalid-name",
-  "missing-class-docstring",
   "missing-function-docstring",
   "missing-module-docstring",
   "no-else-raise",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,8 @@ def pytest_runtest_setup(item):
 
 
 class PyTestOption(object):
+    """Helper class that provides methods for creating and managing an inventory file."""
+
     def __init__(self, config, testdir):
         self.config = config
 

--- a/tests/test_adhoc_result.py
+++ b/tests/test_adhoc_result.py
@@ -98,7 +98,7 @@ def test_connection_failure_v1():
     # Assert msg
     assert "msg" in exc_info.value.dark["unknown.example.com"]
     assert exc_info.value.dark["unknown.example.com"]["msg"].startswith(
-        "SSH Error: ssh: Could not resolve hostname" " unknown.example.com:"
+        "SSH Error: ssh: Could not resolve hostname" + " unknown.example.com:"
     )
 
 


### PR DESCRIPTION
The `implicit-str-concat` check makes sure that the code is using two or more string literals that are separated by any operators or functions to concatenate them together. The check helps to avoid unexpected behavior and makes the code more readable and maintainable. 

The `missing-class-docstring` check ensures that every class has a docstring. A docstring is a string literal that describes the purpose and behavior of a class.  It should be the first statement in the class definition. It helps to maintain the readability of the code.

CC: @ssbarnea @cidrblock 

Related to #85 