### PR TITLE
Add `no-else-raise` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ disable = [
   "invalid-name",
   "missing-function-docstring",
   "missing-module-docstring",
-  "no-else-raise",
   "no-else-return",
   "no-member",
   "no-name-in-module",

--- a/src/pytest_ansible/host_manager/__init__.py
+++ b/src/pytest_ansible/host_manager/__init__.py
@@ -86,17 +86,15 @@ class BaseHostManager(object):
         else:
             if not self.has_matching_inventory(item):
                 raise KeyError(item)
-            else:
-                self.options["host_pattern"] = item
-                return self._dispatcher(**self.options)
+            self.options["host_pattern"] = item
+            return self._dispatcher(**self.options)
 
     def __getattr__(self, attr):
         """Return a ModuleDispatcher instance described the provided `attr`."""
         if not self.has_matching_inventory(attr):
             raise AttributeError(f"type HostManager has no attribute '{attr}'")
-        else:
-            self.options["host_pattern"] = attr
-            return self._dispatcher(**self.options)
+        self.options["host_pattern"] = attr
+        return self._dispatcher(**self.options)
 
     def keys(self):
         inventory_hosts = [

--- a/src/pytest_ansible/module_dispatcher/__init__.py
+++ b/src/pytest_ansible/module_dispatcher/__init__.py
@@ -39,9 +39,8 @@ class BaseModuleDispatcher(object):
             raise AnsibleModuleError(
                 f"The module {name} was not found in configured module paths."
             )
-        else:
-            self.options["module_name"] = name
-            return self._run
+        self.options["module_name"] = name
+        return self._run
 
     def check_required_kwargs(self, **kwargs):
         """Raise a TypeError if any required kwargs are missing."""

--- a/src/pytest_ansible/module_dispatcher/v212.py
+++ b/src/pytest_ansible/module_dispatcher/v212.py
@@ -13,7 +13,6 @@ from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
-from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v212
@@ -21,9 +20,12 @@ from pytest_ansible.module_dispatcher.v2 import ModuleDispatcherV2
 from pytest_ansible.results import AdHocResult
 
 
-# pylint: disable=ungrouped-imports
+# pylint: disable=ungrouped-imports, wrong-import-position
 if not has_ansible_v212:
     raise ImportError("Only supported with ansible-2.12 and newer")
+from ansible.plugins.loader import module_loader
+
+
 # pylint: enable=ungrouped-imports
 
 

--- a/src/pytest_ansible/module_dispatcher/v212.py
+++ b/src/pytest_ansible/module_dispatcher/v212.py
@@ -13,6 +13,7 @@ from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
+from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v212
@@ -23,8 +24,6 @@ from pytest_ansible.results import AdHocResult
 # pylint: disable=ungrouped-imports
 if not has_ansible_v212:
     raise ImportError("Only supported with ansible-2.12 and newer")
-else:
-    from ansible.plugins.loader import module_loader
 # pylint: enable=ungrouped-imports
 
 

--- a/src/pytest_ansible/module_dispatcher/v213.py
+++ b/src/pytest_ansible/module_dispatcher/v213.py
@@ -9,7 +9,6 @@ from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
-from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v213
@@ -17,10 +16,11 @@ from pytest_ansible.module_dispatcher.v2 import ModuleDispatcherV2
 from pytest_ansible.results import AdHocResult
 
 
-# pylint: disable=ungrouped-imports
+# pylint: disable=ungrouped-imports, wrong-import-position
 
 if not has_ansible_v213:
     raise ImportError("Only supported with ansible-2.13 and newer")
+from ansible.plugins.loader import module_loader
 
 
 # pylint: enable=ungrouped-imports

--- a/src/pytest_ansible/module_dispatcher/v213.py
+++ b/src/pytest_ansible/module_dispatcher/v213.py
@@ -9,6 +9,7 @@ from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
+from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v213
@@ -20,8 +21,7 @@ from pytest_ansible.results import AdHocResult
 
 if not has_ansible_v213:
     raise ImportError("Only supported with ansible-2.13 and newer")
-else:
-    from ansible.plugins.loader import module_loader
+
 
 # pylint: enable=ungrouped-imports
 

--- a/src/pytest_ansible/module_dispatcher/v24.py
+++ b/src/pytest_ansible/module_dispatcher/v24.py
@@ -8,7 +8,6 @@ from ansible.cli import CLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
-from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v24
@@ -16,10 +15,11 @@ from pytest_ansible.module_dispatcher.v2 import ModuleDispatcherV2
 from pytest_ansible.results import AdHocResult
 
 
-# pylint: disable=ungrouped-imports
+# pylint: disable=ungrouped-imports, wrong-import-position
 
 if not has_ansible_v24:
     raise ImportError("Only supported with ansible-2.4 and newer")
+from ansible.plugins.loader import module_loader
 
 
 # pylint: enable=ungrouped-imports

--- a/src/pytest_ansible/module_dispatcher/v24.py
+++ b/src/pytest_ansible/module_dispatcher/v24.py
@@ -8,6 +8,7 @@ from ansible.cli import CLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
+from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v24
@@ -19,8 +20,7 @@ from pytest_ansible.results import AdHocResult
 
 if not has_ansible_v24:
     raise ImportError("Only supported with ansible-2.4 and newer")
-else:
-    from ansible.plugins.loader import module_loader
+
 
 # pylint: enable=ungrouped-imports
 

--- a/src/pytest_ansible/module_dispatcher/v28.py
+++ b/src/pytest_ansible/module_dispatcher/v28.py
@@ -9,7 +9,6 @@ from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
-from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v28
@@ -17,11 +16,11 @@ from pytest_ansible.module_dispatcher.v2 import ModuleDispatcherV2
 from pytest_ansible.results import AdHocResult
 
 
-# pylint: disable=ungrouped-imports
-
-
+# pylint: disable=ungrouped-imports, wrong-import-position
 if not has_ansible_v28:
     raise ImportError("Only supported with ansible-2.8 and newer")
+from ansible.plugins.loader import module_loader
+
 
 # pylint: enable=ungrouped-imports
 

--- a/src/pytest_ansible/module_dispatcher/v28.py
+++ b/src/pytest_ansible/module_dispatcher/v28.py
@@ -9,6 +9,7 @@ from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
+from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v28
@@ -21,8 +22,6 @@ from pytest_ansible.results import AdHocResult
 
 if not has_ansible_v28:
     raise ImportError("Only supported with ansible-2.8 and newer")
-else:
-    from ansible.plugins.loader import module_loader
 
 # pylint: enable=ungrouped-imports
 

--- a/src/pytest_ansible/module_dispatcher/v29.py
+++ b/src/pytest_ansible/module_dispatcher/v29.py
@@ -9,7 +9,6 @@ from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
-from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v29
@@ -17,10 +16,12 @@ from pytest_ansible.module_dispatcher.v2 import ModuleDispatcherV2
 from pytest_ansible.results import AdHocResult
 
 
-# pylint: disable=ungrouped-imports
+# pylint: disable=ungrouped-imports, wrong-import-position
 
 if not has_ansible_v29:
     raise ImportError("Only supported with ansible-2.9 and newer")
+from ansible.plugins.loader import module_loader
+
 
 # pylint: enable=ungrouped-imports
 

--- a/src/pytest_ansible/module_dispatcher/v29.py
+++ b/src/pytest_ansible/module_dispatcher/v29.py
@@ -9,6 +9,7 @@ from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
+from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v29
@@ -20,8 +21,6 @@ from pytest_ansible.results import AdHocResult
 
 if not has_ansible_v29:
     raise ImportError("Only supported with ansible-2.9 and newer")
-else:
-    from ansible.plugins.loader import module_loader
 
 # pylint: enable=ungrouped-imports
 


### PR DESCRIPTION
The `no-else-raise` check ensures that there is no unnecessary `else` statement in the code block following a `raise` statement. As the raise statement causes an exception to be thrown, any code following the raise statement will not be executed, which makes the else block redundant and hence this check ensures that there is no else block after a raise statement. It helps to make our code readable amd modular.

Related to #85 
