### PR TITLE
Add `no-else-return` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ disable = [
   "invalid-name",
   "missing-function-docstring",
   "missing-module-docstring",
-  "no-else-return",
   "no-member",
   "no-name-in-module",
   "not-callable",

--- a/src/pytest_ansible/host_manager/__init__.py
+++ b/src/pytest_ansible/host_manager/__init__.py
@@ -83,11 +83,10 @@ class BaseHostManager(object):
 
         if item in self.__dict__:
             return self.__dict__[item]
-        else:
-            if not self.has_matching_inventory(item):
-                raise KeyError(item)
-            self.options["host_pattern"] = item
-            return self._dispatcher(**self.options)
+        if not self.has_matching_inventory(item):
+            raise KeyError(item)
+        self.options["host_pattern"] = item
+        return self._dispatcher(**self.options)
 
     def __getattr__(self, attr):
         """Return a ModuleDispatcher instance described the provided `attr`."""

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -23,8 +23,7 @@ def become_methods():
     """Return string list of become methods available to ansible."""
     if become_loader:
         return [method.name for method in become_loader.all()]
-    else:
-        return ansible.constants.BECOME_METHODS
+    return ansible.constants.BECOME_METHODS
 
 
 def pytest_addoption(parser):

--- a/src/pytest_ansible/results.py
+++ b/src/pytest_ansible/results.py
@@ -59,15 +59,13 @@ class AdHocResult(object):
         """Return a ModuleResult instance matching the provided `item`."""
         if item in self.contacted:
             return ModuleResult(**self.contacted[item])
-        else:
-            raise KeyError(item)
+        raise KeyError(item)
 
     def __getattr__(self, attr):
         """Return a ModuleResult instance matching the provided `attr`."""
         if attr in self.contacted:
             return ModuleResult(**self.contacted[attr])
-        else:
-            raise AttributeError(f"type AdHocResult has no attribute '{attr}'")
+        raise AttributeError(f"type AdHocResult has no attribute '{attr}'")
 
     def __len__(self):
         """Return the number of contacted hosts."""


### PR DESCRIPTION
The `no-else-return` check is a linting error that usually appears when you have an "else" statement immediately following a "return" statement in a function. The check suggests that you should remove the "else" statement and de-indent the code inside it. This ensures that the code inside the "else" block is not executed unnecessarily and will also make the code more concise and easier to read.