### PR TITLE
Add `super-with-arguments` & `too-few-public-methods` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,8 +93,6 @@ disable = [
   "no-name-in-module",
   "protected-access",
   "redefined-outer-name",
-  "super-with-arguments",
-  "too-few-public-methods",
   "too-many-branches",
   "too-many-locals",
   "too-many-statements",

--- a/src/pytest_ansible/errors.py
+++ b/src/pytest_ansible/errors.py
@@ -16,7 +16,7 @@ class AnsibleConnectionFailure(ansible.errors.AnsibleError):
 
     def __init__(self, msg, dark=None, contacted=None):
         """Initialize connection error class."""
-        super(AnsibleConnectionFailure, self).__init__(msg)
+        super().__init__(msg)
         self.contacted = contacted
         self.dark = dark
 

--- a/src/pytest_ansible/host_manager/v1.py
+++ b/src/pytest_ansible/host_manager/v1.py
@@ -10,7 +10,7 @@ class HostManagerV1(BaseHostManager):
 
     def __init__(self, *args, **kwargs):
         """Fixme."""
-        super(HostManagerV1, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._dispatcher = ModuleDispatcherV1
 
     def keys(self):

--- a/src/pytest_ansible/host_manager/v2.py
+++ b/src/pytest_ansible/host_manager/v2.py
@@ -12,7 +12,7 @@ class HostManagerV2(BaseHostManager):
 
     def __init__(self, *args, **kwargs):
         """Fixme."""
-        super(HostManagerV2, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._dispatcher = ModuleDispatcherV2
 
     def initialize_inventory(self):

--- a/src/pytest_ansible/host_manager/v212.py
+++ b/src/pytest_ansible/host_manager/v212.py
@@ -11,7 +11,7 @@ class HostManagerV212(BaseHostManager):
 
     def __init__(self, *args, **kwargs):
         """Fixme."""
-        super(HostManagerV212, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._dispatcher = ModuleDispatcherV212
 
     def initialize_inventory(self):

--- a/src/pytest_ansible/host_manager/v213.py
+++ b/src/pytest_ansible/host_manager/v213.py
@@ -11,7 +11,7 @@ class HostManagerV213(BaseHostManager):
 
     def __init__(self, *args, **kwargs):
         """Fixme."""
-        super(HostManagerV213, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._dispatcher = ModuleDispatcherV213
 
     def initialize_inventory(self):

--- a/src/pytest_ansible/host_manager/v24.py
+++ b/src/pytest_ansible/host_manager/v24.py
@@ -12,7 +12,7 @@ class HostManagerV24(BaseHostManager):
 
     def __init__(self, *args, **kwargs):
         """Fixme."""
-        super(HostManagerV24, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._dispatcher = ModuleDispatcherV24
 
     def initialize_inventory(self):

--- a/src/pytest_ansible/host_manager/v28.py
+++ b/src/pytest_ansible/host_manager/v28.py
@@ -12,7 +12,7 @@ class HostManagerV28(BaseHostManager):
 
     def __init__(self, *args, **kwargs):
         """Fixme."""
-        super(HostManagerV28, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._dispatcher = ModuleDispatcherV28
 
     def initialize_inventory(self):

--- a/src/pytest_ansible/host_manager/v29.py
+++ b/src/pytest_ansible/host_manager/v29.py
@@ -11,7 +11,7 @@ class HostManagerV29(BaseHostManager):
 
     def __init__(self, *args, **kwargs):
         """Fixme."""
-        super(HostManagerV29, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._dispatcher = ModuleDispatcherV29
 
     def initialize_inventory(self):

--- a/src/pytest_ansible/module_dispatcher/v2.py
+++ b/src/pytest_ansible/module_dispatcher/v2.py
@@ -30,7 +30,7 @@ class ResultAccumulator(CallbackBase):
 
     def __init__(self, *args, **kwargs):
         """Initialize object."""
-        super(ResultAccumulator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.contacted = {}
         self.unreachable = {}
 

--- a/src/pytest_ansible/module_dispatcher/v212.py
+++ b/src/pytest_ansible/module_dispatcher/v212.py
@@ -34,7 +34,7 @@ class ResultAccumulator(CallbackBase):
 
     def __init__(self, *args, **kwargs):
         """Initialize object."""
-        super(ResultAccumulator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.contacted = {}
         self.unreachable = {}
 

--- a/src/pytest_ansible/module_dispatcher/v213.py
+++ b/src/pytest_ansible/module_dispatcher/v213.py
@@ -31,7 +31,7 @@ class ResultAccumulator(CallbackBase):
 
     def __init__(self, *args, **kwargs):
         """Initialize object."""
-        super(ResultAccumulator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.contacted = {}
         self.unreachable = {}
 

--- a/src/pytest_ansible/module_dispatcher/v24.py
+++ b/src/pytest_ansible/module_dispatcher/v24.py
@@ -31,7 +31,7 @@ class ResultAccumulator(CallbackBase):
 
     def __init__(self, *args, **kwargs):
         """Initialize object."""
-        super(ResultAccumulator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.contacted = {}
         self.unreachable = {}
 

--- a/src/pytest_ansible/module_dispatcher/v28.py
+++ b/src/pytest_ansible/module_dispatcher/v28.py
@@ -30,7 +30,7 @@ class ResultAccumulator(CallbackBase):
 
     def __init__(self, *args, **kwargs):
         """Initialize object."""
-        super(ResultAccumulator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.contacted = {}
         self.unreachable = {}
 

--- a/src/pytest_ansible/module_dispatcher/v29.py
+++ b/src/pytest_ansible/module_dispatcher/v29.py
@@ -31,7 +31,7 @@ class ResultAccumulator(CallbackBase):
 
     def __init__(self, *args, **kwargs):
         """Initialize object."""
-        super(ResultAccumulator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.contacted = {}
         self.unreachable = {}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,7 @@ def pytest_runtest_setup(item):
             )
 
 
+# pylint: disable=too-few-public-methods
 class PyTestOption(object):
     """Helper class that provides methods for creating and managing an inventory file."""
 


### PR DESCRIPTION
The `super-with-arguments` error is a linting error that occurs when calling the `super()` function with arguments. In Python 3, it's recommended to use the super() function without arguments, as it will automatically infer the correct superclass and arguments.

The `too-few-public-method ` check indicates that the class has very few public methods and may not be well-designed for reuse or extension. To fix this error, we need to refactor the class to add more public methods or convert it into a module or a function if it's not needed as a class. For now I have added the `#pylint` comment for it but in future we can try to refactor the code which can make it more modular. @ssbarnea @cidrblock 

Related to #85 
