### PR TITLE
Add `unused-import` & `wrong-import-order` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ disable = [
   "too-many-statements",
   "unexpected-keyword-arg",
   "unused-argument",
-  "unused-import",
   "unused-variable",
   "use-a-generator",
   "use-dict-literal",
@@ -106,7 +105,6 @@ disable = [
   "used-before-assignment",
   "useless-object-inheritance",
   "using-constant-test",
-  "wrong-import-order",
 ]
 
 [tool.pytest]

--- a/src/pytest_ansible/module_dispatcher/v2.py
+++ b/src/pytest_ansible/module_dispatcher/v2.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import warnings
 
-from typing import Any
 from typing import Sequence
 
 import ansible.constants

--- a/src/pytest_ansible/module_dispatcher/v212.py
+++ b/src/pytest_ansible/module_dispatcher/v212.py
@@ -13,6 +13,7 @@ from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
+from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v212
@@ -23,7 +24,6 @@ from pytest_ansible.results import AdHocResult
 # pylint: disable=ungrouped-imports, wrong-import-position
 if not has_ansible_v212:
     raise ImportError("Only supported with ansible-2.12 and newer")
-from ansible.plugins.loader import module_loader
 
 
 # pylint: enable=ungrouped-imports

--- a/src/pytest_ansible/module_dispatcher/v213.py
+++ b/src/pytest_ansible/module_dispatcher/v213.py
@@ -9,6 +9,7 @@ from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
+from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v213
@@ -20,7 +21,6 @@ from pytest_ansible.results import AdHocResult
 
 if not has_ansible_v213:
     raise ImportError("Only supported with ansible-2.13 and newer")
-from ansible.plugins.loader import module_loader
 
 
 # pylint: enable=ungrouped-imports

--- a/src/pytest_ansible/module_dispatcher/v24.py
+++ b/src/pytest_ansible/module_dispatcher/v24.py
@@ -8,6 +8,7 @@ from ansible.cli import CLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
+from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v24
@@ -19,7 +20,6 @@ from pytest_ansible.results import AdHocResult
 
 if not has_ansible_v24:
     raise ImportError("Only supported with ansible-2.4 and newer")
-from ansible.plugins.loader import module_loader
 
 
 # pylint: enable=ungrouped-imports

--- a/src/pytest_ansible/module_dispatcher/v28.py
+++ b/src/pytest_ansible/module_dispatcher/v28.py
@@ -9,6 +9,7 @@ from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
+from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v28
@@ -19,7 +20,6 @@ from pytest_ansible.results import AdHocResult
 # pylint: disable=ungrouped-imports, wrong-import-position
 if not has_ansible_v28:
     raise ImportError("Only supported with ansible-2.8 and newer")
-from ansible.plugins.loader import module_loader
 
 
 # pylint: enable=ungrouped-imports

--- a/src/pytest_ansible/module_dispatcher/v29.py
+++ b/src/pytest_ansible/module_dispatcher/v29.py
@@ -9,6 +9,7 @@ from ansible.cli.adhoc import AdHocCLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
+from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v29
@@ -20,7 +21,6 @@ from pytest_ansible.results import AdHocResult
 
 if not has_ansible_v29:
     raise ImportError("Only supported with ansible-2.9 and newer")
-from ansible.plugins.loader import module_loader
 
 
 # pylint: enable=ungrouped-imports

--- a/src/pytest_ansible/results.py
+++ b/src/pytest_ansible/results.py
@@ -1,7 +1,5 @@
 """Fixme."""
 
-import ansible.errors  # NOQA
-
 
 class ModuleResult(dict):
 

--- a/tests/test_adhoc.py
+++ b/tests/test_adhoc.py
@@ -1,6 +1,7 @@
 import pytest
 
 
+# pylint: disable=unused-import
 try:
     from _pytest.main import EXIT_INTERRUPTED  # type: ignore[attr-defined]
     from _pytest.main import EXIT_NOTESTSCOLLECTED  # type: ignore[attr-defined]

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,3 +1,4 @@
+# pylint: disable=unused-import
 import pytest
 
 

--- a/tests/test_module_dispatcher.py
+++ b/tests/test_module_dispatcher.py
@@ -15,6 +15,7 @@ def test_runtime_error():
         bmd._run("foo")
 
 
+# pylint: disable=unused-import
 @pytest.mark.requires_ansible_v1
 def test_importerror_requires_v2():
     with pytest.raises(ImportError):

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -11,6 +11,7 @@ from pkg_resources import parse_version
 from pytest_ansible.has_version import has_ansible_v28
 
 
+# pylint: disable=unused-import
 try:
     from _pytest.main import EXIT_INTERRUPTED  # type: ignore[attr-defined]
     from _pytest.main import EXIT_NOTESTSCOLLECTED  # type: ignore[attr-defined]
@@ -26,6 +27,7 @@ except ImportError:
     EXIT_INTERRUPTED = ExitCode.INTERRUPTED
     EXIT_NOTESTSCOLLECTED = ExitCode.NO_TESTS_COLLECTED
 
+# pylint: disable=unused-import
 if sys.version_info[0] == 2:
     import __builtin__ as builtins  # NOQA
 else:


### PR DESCRIPTION
The `unused-import` check ensures that there is no imported module unused in the codebase.

The `wrong-import-order` check ensures that the imported module follows recommended conventions. The recommended convention is to import built-in modules first, followed by third-party modules, and then local modules.
By following this convention, our code becomes more readable and easier to maintain, as it is easier to identify where each module is coming from.

Related to #85 