### PR TITLE
Add `use-dict-literal`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ disable = [
   "too-many-statements",
   "unexpected-keyword-arg",
   "unused-argument",
-  "use-dict-literal",
   "used-before-assignment",
 ]
 

--- a/src/pytest_ansible/module_dispatcher/v1.py
+++ b/src/pytest_ansible/module_dispatcher/v1.py
@@ -40,7 +40,7 @@ class ModuleDispatcherV1(BaseModuleDispatcher):
         """Execute an ansible adhoc command returning the results in a AdHocResult object."""
         # Assemble module argument string
         if module_args:
-            complex_args.update(dict(_raw_params=" ".join(module_args)))
+            complex_args.update({"_raw_params": " ".join(module_args)})
         else:
             module_args = " ".join(module_args)
 
@@ -61,19 +61,19 @@ class ModuleDispatcherV1(BaseModuleDispatcher):
             )
 
         # Build module runner object
-        kwargs = dict(
-            inventory=self.options.get("inventory_manager"),
-            pattern=self.options.get("host_pattern"),
-            module_name=self.options.get("module_name"),
-            module_args=module_args,
-            complex_args=complex_args,
-            transport=self.options.get("connection"),
-            remote_user=self.options.get("user"),
-            module_path=self.options.get("module_path"),
-            become=self.options.get("become"),
-            become_method=self.options.get("become_method"),
-            become_user=self.options.get("become_user"),
-        )
+        kwargs = {
+            "inventory": self.options.get("inventory_manager"),
+            "pattern": self.options.get("host_pattern"),
+            "module_name": self.options.get("module_name"),
+            "module_args": module_args,
+            "complex_args": complex_args,
+            "transport": self.options.get("connection"),
+            "remote_user": self.options.get("user"),
+            "module_path": self.options.get("module_path"),
+            "become": self.options.get("become"),
+            "become_method": self.options.get("become_method"),
+            "become_user": self.options.get("become_user"),
+        }
 
         # Run the module
         runner = Runner(**kwargs)

--- a/src/pytest_ansible/module_dispatcher/v2.py
+++ b/src/pytest_ansible/module_dispatcher/v2.py
@@ -43,7 +43,7 @@ class ResultAccumulator(CallbackBase):
 
     @property
     def results(self):
-        return dict(contacted=self.contacted, unreachable=self.unreachable)
+        return {"contacted": self.contacted, "unreachable": self.unreachable}
 
 
 class ModuleDispatcherV2(BaseModuleDispatcher):
@@ -75,7 +75,7 @@ class ModuleDispatcherV2(BaseModuleDispatcher):
         """Execute an ansible adhoc command returning the result in a AdhocResult object."""
         # Assemble module argument string
         if module_args:
-            complex_args.update(dict(_raw_params=" ".join(module_args)))
+            complex_args.update({"_raw_params": " ".join(module_args)})
 
         # Assert hosts matching the provided pattern exist
         hosts = self.options["inventory_manager"].list_hosts()
@@ -119,26 +119,30 @@ class ModuleDispatcherV2(BaseModuleDispatcher):
         # Initialize callback to capture module JSON responses
         cb = ResultAccumulator()
 
-        kwargs = dict(
-            inventory=self.options["inventory_manager"],
-            variable_manager=self.options["variable_manager"],
-            loader=self.options["loader"],
-            options=options,
-            stdout_callback=cb,
-            passwords=dict(conn_pass=None, become_pass=None),
-        )
+        kwargs = {
+            "inventory": self.options["inventory_manager"],
+            "variable_manager": self.options["variable_manager"],
+            "loader": self.options["loader"],
+            "options": options,
+            "stdout_callback": cb,
+            "passwords": {"conn_pass": None, "become_pass": None},
+        }
 
         # create a pseudo-play to execute the specified module via a single task
-        play_ds = dict(
-            name="pytest-ansible",
-            hosts=self.options["host_pattern"],
-            gather_facts="no",
-            tasks=[
-                dict(
-                    action=dict(module=self.options["module_name"], args=complex_args),
-                ),
+        play_ds = {
+            "name": "pytest-ansible",
+            "hosts": self.options["host_pattern"],
+            "gather_facts": "no",
+            "tasks": [
+                {
+                    "action": {
+                        "module": self.options["module_name"],
+                        "args": complex_args,
+                    }
+                }
             ],
-        )
+        }
+
         play = Play().load(
             play_ds,
             variable_manager=self.options["variable_manager"],

--- a/src/pytest_ansible/module_dispatcher/v212.py
+++ b/src/pytest_ansible/module_dispatcher/v212.py
@@ -39,7 +39,7 @@ class ResultAccumulator(CallbackBase):
         self.unreachable = {}
 
     def v2_runner_on_failed(self, result, *args, **kwargs):
-        result2 = dict(failed=True)
+        result2 = {"failed": True}
         result2.update(result._result)
         self.contacted[result._host.get_name()] = result2
 
@@ -51,7 +51,7 @@ class ResultAccumulator(CallbackBase):
 
     @property
     def results(self):
-        return dict(contacted=self.contacted, unreachable=self.unreachable)
+        return {"contacted": self.contacted, "unreachable": self.unreachable}
 
 
 class ModuleDispatcherV212(ModuleDispatcherV2):
@@ -82,7 +82,7 @@ class ModuleDispatcherV212(ModuleDispatcherV2):
         """Execute an ansible adhoc command returning the result in a AdhocResult object."""
         # Assemble module argument string
         if module_args:
-            complex_args.update(dict(_raw_params=" ".join(module_args)))
+            complex_args.update({"_raw_params": " ".join(module_args)})
 
         # Assert hosts matching the provided pattern exist
         hosts = self.options["inventory_manager"].list_hosts()
@@ -140,39 +140,42 @@ class ModuleDispatcherV212(ModuleDispatcherV2):
         # Initialize callbacks to capture module JSON responses
         cb = ResultAccumulator()
 
-        kwargs = dict(
-            inventory=self.options["inventory_manager"],
-            variable_manager=self.options["variable_manager"],
-            loader=self.options["loader"],
-            stdout_callback=cb,
-            passwords=dict(conn_pass=None, become_pass=None),
-        )
+        kwargs = {
+            "inventory": self.options["inventory_manager"],
+            "variable_manager": self.options["variable_manager"],
+            "loader": self.options["loader"],
+            "stdout_callback": cb,
+            "passwords": {"conn_pass": None, "become_pass": None},
+        }
 
         # If we have an extra inventory, do the same that we did for the inventory
         if "extra_inventory_manager" in self.options:
             cb_extra = ResultAccumulator()
 
-            kwargs_extra = dict(
-                inventory=self.options["extra_inventory_manager"],
-                variable_manager=self.options["extra_variable_manager"],
-                loader=self.options["extra_loader"],
-                stdout_callback=cb_extra,
-                passwords=dict(conn_pass=None, become_pass=None),
-            )
+            kwargs_extra = {
+                "inventory": self.options["extra_inventory_manager"],
+                "variable_manager": self.options["extra_variable_manager"],
+                "loader": self.options["extra_loader"],
+                "stdout_callback": cb_extra,
+                "passwords": {"conn_pass": None, "become_pass": None},
+            }
 
         # create a pseudo-play to execute the specified module via a single task
-        play_ds = dict(
-            name="pytest-ansible",
-            hosts=self.options["host_pattern"],
-            become=self.options.get("become"),
-            become_user=self.options.get("become_user"),
-            gather_facts="no",
-            tasks=[
-                dict(
-                    action=dict(module=self.options["module_name"], args=complex_args),
-                ),
+        play_ds = {
+            "name": "pytest-ansible",
+            "hosts": self.options["host_pattern"],
+            "become": self.options.get("become"),
+            "become_user": self.options.get("become_user"),
+            "gather_facts": "no",
+            "tasks": [
+                {
+                    "action": {
+                        "module": self.options["module_name"],
+                        "args": complex_args,
+                    },
+                },
             ],
-        )
+        }
 
         play = Play().load(
             play_ds,

--- a/src/pytest_ansible/module_dispatcher/v213.py
+++ b/src/pytest_ansible/module_dispatcher/v213.py
@@ -36,7 +36,7 @@ class ResultAccumulator(CallbackBase):
         self.unreachable = {}
 
     def v2_runner_on_failed(self, result, *args, **kwargs):
-        result2 = dict(failed=True)
+        result2 = {"failed": True}
         result2.update(result._result)
         self.contacted[result._host.get_name()] = result2
 
@@ -48,7 +48,7 @@ class ResultAccumulator(CallbackBase):
 
     @property
     def results(self):
-        return dict(contacted=self.contacted, unreachable=self.unreachable)
+        return {"contacted": self.contacted, "unreachable": self.unreachable}
 
 
 class ModuleDispatcherV213(ModuleDispatcherV2):
@@ -79,7 +79,7 @@ class ModuleDispatcherV213(ModuleDispatcherV2):
         """Execute an ansible adhoc command returning the result in a AdhocResult object."""
         # Assemble module argument string
         if module_args:
-            complex_args.update(dict(_raw_params=" ".join(module_args)))
+            complex_args.update({"_raw_params": " ".join(module_args)})
 
         # Assert hosts matching the provided pattern exist
         hosts = self.options["inventory_manager"].list_hosts()
@@ -146,39 +146,42 @@ class ModuleDispatcherV213(ModuleDispatcherV2):
         # Initialize callbacks to capture module JSON responses
         cb = ResultAccumulator()
 
-        kwargs = dict(
-            inventory=self.options["inventory_manager"],
-            variable_manager=self.options["variable_manager"],
-            loader=self.options["loader"],
-            stdout_callback=cb,
-            passwords=dict(conn_pass=None, become_pass=None),
-        )
+        kwargs = {
+            "inventory": self.options["inventory_manager"],
+            "variable_manager": self.options["variable_manager"],
+            "loader": self.options["loader"],
+            "stdout_callback": cb,
+            "passwords": {"conn_pass": None, "become_pass": None},
+        }
 
         # If we have an extra inventory, do the same that we did for the inventory
         if "extra_inventory_manager" in self.options:
             cb_extra = ResultAccumulator()
 
-            kwargs_extra = dict(
-                inventory=self.options["extra_inventory_manager"],
-                variable_manager=self.options["extra_variable_manager"],
-                loader=self.options["extra_loader"],
-                stdout_callback=cb_extra,
-                passwords=dict(conn_pass=None, become_pass=None),
-            )
+            kwargs_extra = {
+                "inventory": self.options["extra_inventory_manager"],
+                "variable_manager": self.options["extra_variable_manager"],
+                "loader": self.options["extra_loader"],
+                "stdout_callback": cb_extra,
+                "passwords": {"conn_pass": None, "become_pass": None},
+            }
 
         # create a pseudo-play to execute the specified module via a single task
-        play_ds = dict(
-            name="pytest-ansible",
-            hosts=self.options["host_pattern"],
-            become=self.options.get("become"),
-            become_user=self.options.get("become_user"),
-            gather_facts="no",
-            tasks=[
-                dict(
-                    action=dict(module=self.options["module_name"], args=complex_args),
-                ),
+        play_ds = {
+            "name": "pytest-ansible",
+            "hosts": self.options["host_pattern"],
+            "become": self.options.get("become"),
+            "become_user": self.options.get("become_user"),
+            "gather_facts": "no",
+            "tasks": [
+                {
+                    "action": {
+                        "module": self.options["module_name"],
+                        "args": complex_args,
+                    },
+                }
             ],
-        )
+        }
 
         play = Play().load(
             play_ds,

--- a/src/pytest_ansible/module_dispatcher/v24.py
+++ b/src/pytest_ansible/module_dispatcher/v24.py
@@ -45,7 +45,7 @@ class ResultAccumulator(CallbackBase):
 
     @property
     def results(self):
-        return dict(contacted=self.contacted, unreachable=self.unreachable)
+        return {"contacted": self.contacted, "unreachable": self.unreachable}
 
 
 class ModuleDispatcherV24(ModuleDispatcherV2):
@@ -77,7 +77,7 @@ class ModuleDispatcherV24(ModuleDispatcherV2):
         """Execute an ansible adhoc command returning the result in a AdhocResult object."""
         # Assemble module argument string
         if module_args:
-            complex_args.update(dict(_raw_params=" ".join(module_args)))
+            complex_args.update({"_raw_params": " ".join(module_args)})
 
         # Assert hosts matching the provided pattern exist
         hosts = self.options["inventory_manager"].list_hosts()
@@ -121,26 +121,30 @@ class ModuleDispatcherV24(ModuleDispatcherV2):
         # Initialize callback to capture module JSON responses
         cb = ResultAccumulator()
 
-        kwargs = dict(
-            inventory=self.options["inventory_manager"],
-            variable_manager=self.options["variable_manager"],
-            loader=self.options["loader"],
-            options=options,
-            stdout_callback=cb,
-            passwords=dict(conn_pass=None, become_pass=None),
-        )
+        kwargs = {
+            "inventory": self.options["inventory_manager"],
+            "variable_manager": self.options["variable_manager"],
+            "loader": self.options["loader"],
+            "options": options,
+            "stdout_callback": cb,
+            "passwords": {"conn_pass": None, "become_pass": None},
+        }
 
         # create a pseudo-play to execute the specified module via a single task
-        play_ds = dict(
-            name="pytest-ansible",
-            hosts=self.options["host_pattern"],
-            gather_facts="no",
-            tasks=[
-                dict(
-                    action=dict(module=self.options["module_name"], args=complex_args),
-                ),
+        play_ds = {
+            "name": "pytest-ansible",
+            "hosts": self.options["host_pattern"],
+            "gather_facts": "no",
+            "tasks": [
+                {
+                    "action": {
+                        "module": self.options["module_name"],
+                        "args": complex_args,
+                    },
+                },
             ],
-        )
+        }
+
         play = Play().load(
             play_ds,
             variable_manager=self.options["variable_manager"],

--- a/src/pytest_ansible/module_dispatcher/v28.py
+++ b/src/pytest_ansible/module_dispatcher/v28.py
@@ -35,7 +35,7 @@ class ResultAccumulator(CallbackBase):
         self.unreachable = {}
 
     def v2_runner_on_failed(self, result, *args, **kwargs):
-        result2 = dict(failed=True)
+        result2 = {"failed": True}
         result2.update(result._result)
         self.contacted[result._host.get_name()] = result2
 
@@ -47,7 +47,7 @@ class ResultAccumulator(CallbackBase):
 
     @property
     def results(self):
-        return dict(contacted=self.contacted, unreachable=self.unreachable)
+        return {"contacted": self.contacted, "unreachable": self.unreachable}
 
 
 class ModuleDispatcherV28(ModuleDispatcherV2):
@@ -78,7 +78,7 @@ class ModuleDispatcherV28(ModuleDispatcherV2):
         """Execute an ansible adhoc command returning the result in a AdhocResult object."""
         # Assemble module argument string
         if module_args:
-            complex_args.update(dict(_raw_params=" ".join(module_args)))
+            complex_args.update({"_raw_params": " ".join(module_args)})
 
         # Assert hosts matching the provided pattern exist
         hosts = self.options["inventory_manager"].list_hosts()
@@ -136,27 +136,31 @@ class ModuleDispatcherV28(ModuleDispatcherV2):
         # Initialize callback to capture module JSON responses
         cb = ResultAccumulator()
 
-        kwargs = dict(
-            inventory=self.options["inventory_manager"],
-            variable_manager=self.options["variable_manager"],
-            loader=self.options["loader"],
-            stdout_callback=cb,
-            passwords=dict(conn_pass=None, become_pass=None),
-        )
+        kwargs = {
+            "inventory": self.options["inventory_manager"],
+            "variable_manager": self.options["variable_manager"],
+            "loader": self.options["loader"],
+            "stdout_callback": cb,
+            "passwords": {"conn_pass": None, "become_pass": None},
+        }
 
         # create a pseudo-play to execute the specified module via a single task
-        play_ds = dict(
-            name="pytest-ansible",
-            hosts=self.options["host_pattern"],
-            become=self.options.get("become"),
-            become_user=self.options.get("become_user"),
-            gather_facts="no",
-            tasks=[
-                dict(
-                    action=dict(module=self.options["module_name"], args=complex_args),
-                ),
+        play_ds = {
+            "name": "pytest-ansible",
+            "hosts": self.options["host_pattern"],
+            "become": self.options.get("become"),
+            "become_user": self.options.get("become_user"),
+            "gather_facts": "no",
+            "tasks": [
+                {
+                    "action": {
+                        "module": self.options["module_name"],
+                        "args": complex_args,
+                    },
+                },
             ],
-        )
+        }
+
         play = Play().load(
             play_ds,
             variable_manager=self.options["variable_manager"],

--- a/src/pytest_ansible/module_dispatcher/v29.py
+++ b/src/pytest_ansible/module_dispatcher/v29.py
@@ -36,7 +36,7 @@ class ResultAccumulator(CallbackBase):
         self.unreachable = {}
 
     def v2_runner_on_failed(self, result, *args, **kwargs):
-        result2 = dict(failed=True)
+        result2 = {"failed": True}
         result2.update(result._result)
         self.contacted[result._host.get_name()] = result2
 
@@ -48,7 +48,7 @@ class ResultAccumulator(CallbackBase):
 
     @property
     def results(self):
-        return dict(contacted=self.contacted, unreachable=self.unreachable)
+        return {"contacted": self.contacted, "unreachable": self.unreachable}
 
 
 class ModuleDispatcherV29(ModuleDispatcherV2):
@@ -79,7 +79,7 @@ class ModuleDispatcherV29(ModuleDispatcherV2):
         """Execute an ansible adhoc command returning the result in a AdhocResult object."""
         # Assemble module argument string
         if module_args:
-            complex_args.update(dict(_raw_params=" ".join(module_args)))
+            complex_args.update({"_raw_params": " ".join(module_args)})
 
         # Assert hosts matching the provided pattern exist
         hosts = self.options["inventory_manager"].list_hosts()
@@ -137,39 +137,42 @@ class ModuleDispatcherV29(ModuleDispatcherV2):
         # Initialize callbacks to capture module JSON responses
         cb = ResultAccumulator()
 
-        kwargs = dict(
-            inventory=self.options["inventory_manager"],
-            variable_manager=self.options["variable_manager"],
-            loader=self.options["loader"],
-            stdout_callback=cb,
-            passwords=dict(conn_pass=None, become_pass=None),
-        )
+        kwargs = {
+            "inventory": self.options["inventory_manager"],
+            "variable_manager": self.options["variable_manager"],
+            "loader": self.options["loader"],
+            "stdout_callback": cb,
+            "passwords": {"conn_pass": None, "become_pass": None},
+        }
 
         # If we have an extra inventory, do the same that we did for the inventory
         if "extra_inventory_manager" in self.options:
             cb_extra = ResultAccumulator()
 
-            kwargs_extra = dict(
-                inventory=self.options["extra_inventory_manager"],
-                variable_manager=self.options["extra_variable_manager"],
-                loader=self.options["extra_loader"],
-                stdout_callback=cb_extra,
-                passwords=dict(conn_pass=None, become_pass=None),
-            )
+            kwargs_extra = {
+                "inventory": self.options["extra_inventory_manager"],
+                "variable_manager": self.options["extra_variable_manager"],
+                "loader": self.options["extra_loader"],
+                "stdout_callback": cb_extra,
+                "passwords": {"conn_pass": None, "become_pass": None},
+            }
 
         # create a pseudo-play to execute the specified module via a single task
-        play_ds = dict(
-            name="pytest-ansible",
-            hosts=self.options["host_pattern"],
-            become=self.options.get("become"),
-            become_user=self.options.get("become_user"),
-            gather_facts="no",
-            tasks=[
-                dict(
-                    action=dict(module=self.options["module_name"], args=complex_args),
-                ),
+        play_ds = {
+            "name": "pytest-ansible",
+            "hosts": self.options["host_pattern"],
+            "become": self.options.get("become"),
+            "become_user": self.options.get("become_user"),
+            "gather_facts": "no",
+            "tasks": [
+                {
+                    "action": {
+                        "module": self.options["module_name"],
+                        "args": complex_args,
+                    },
+                },
             ],
-        )
+        }
 
         play = Play().load(
             play_ds,

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -246,7 +246,7 @@ class PyTestAnsiblePlugin:
             "ansible_subset",
         ]
 
-        kwargs = dict()
+        kwargs = {}
 
         # Load command-line supplied values
         for key in option_names:
@@ -266,7 +266,7 @@ class PyTestAnsiblePlugin:
 
     def _load_request_config(self, request):
         """Load ansible configuration from decorator kwargs."""
-        kwargs = dict()
+        kwargs = {}
 
         # Override options from @pytest.mark.ansible
         marker = request.node.get_closest_marker("ansible")
@@ -277,7 +277,7 @@ class PyTestAnsiblePlugin:
 
     def initialize(self, config=None, request=None, **kwargs):
         """Return an initialized Ansible Host Manager instance."""
-        ansible_cfg = dict()
+        ansible_cfg = {}
         # merge command-line configuration options
         if config is not None:
             ansible_cfg.update(self._load_ansible_config(config))


### PR DESCRIPTION
The `use-dict-literal` check suggests to use dictionary literal instead of the `dict()` constructor. Using a dictionary literal instead of the `dict()` constructor can make our code more concise and easier to read, especially when creating small dictionaries. It can also help catch errors early, since dictionary literals are checked at compile time for correct syntax.