### PR TITLE
Add `used-before-assignment` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ disable = [
   "too-many-statements",
   "unexpected-keyword-arg",
   "unused-argument",
-  "used-before-assignment",
 ]
 
 [tool.pytest]

--- a/src/pytest_ansible/module_dispatcher/v212.py
+++ b/src/pytest_ansible/module_dispatcher/v212.py
@@ -148,6 +148,7 @@ class ModuleDispatcherV212(ModuleDispatcherV2):
             "passwords": {"conn_pass": None, "become_pass": None},
         }
 
+        kwargs_extra = {}
         # If we have an extra inventory, do the same that we did for the inventory
         if "extra_inventory_manager" in self.options:
             cb_extra = ResultAccumulator()
@@ -182,6 +183,8 @@ class ModuleDispatcherV212(ModuleDispatcherV2):
             variable_manager=self.options["variable_manager"],
             loader=self.options["loader"],
         )
+
+        play_extra = None
         if "extra_inventory_manager" in self.options:
             play_extra = Play().load(
                 play_ds,

--- a/src/pytest_ansible/module_dispatcher/v213.py
+++ b/src/pytest_ansible/module_dispatcher/v213.py
@@ -162,6 +162,7 @@ class ModuleDispatcherV213(ModuleDispatcherV2):
             "passwords": {"conn_pass": None, "become_pass": None},
         }
 
+        kwargs_extra = {}
         # If we have an extra inventory, do the same that we did for the inventory
         if "extra_inventory_manager" in self.options:
             cb_extra = ResultAccumulator()
@@ -196,6 +197,7 @@ class ModuleDispatcherV213(ModuleDispatcherV2):
             variable_manager=self.options["variable_manager"],
             loader=self.options["loader"],
         )
+        play_extra = None
         if "extra_inventory_manager" in self.options:
             play_extra = Play().load(
                 play_ds,

--- a/src/pytest_ansible/module_dispatcher/v29.py
+++ b/src/pytest_ansible/module_dispatcher/v29.py
@@ -145,6 +145,7 @@ class ModuleDispatcherV29(ModuleDispatcherV2):
             "passwords": {"conn_pass": None, "become_pass": None},
         }
 
+        kwargs_extra = {}
         # If we have an extra inventory, do the same that we did for the inventory
         if "extra_inventory_manager" in self.options:
             cb_extra = ResultAccumulator()
@@ -179,6 +180,7 @@ class ModuleDispatcherV29(ModuleDispatcherV2):
             variable_manager=self.options["variable_manager"],
             loader=self.options["loader"],
         )
+        play_extra = None
         if "extra_inventory_manager" in self.options:
             play_extra = Play().load(
                 play_ds,


### PR DESCRIPTION
The `used-before-assignment` error occurs when a variable is accessed before it has been assigned a value. This usually happens when the variable is defined inside a conditional statement, loop, or a function and its scope is not properly defined. Hence this check ensures that scope is properly defined.