### PR TITLE
Add `no-member` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ disable = [
   "invalid-name",
   "missing-function-docstring",
   "missing-module-docstring",
-  "no-member",
   "no-name-in-module",
   "protected-access",
   "redefined-outer-name",

--- a/src/pytest_ansible/module_dispatcher/v1.py
+++ b/src/pytest_ansible/module_dispatcher/v1.py
@@ -5,6 +5,7 @@ import ansible.constants
 import ansible.errors
 import ansible.utils
 from ansible.runner import Runner
+from ansible.utils import module_finder
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v1
@@ -31,7 +32,7 @@ class ModuleDispatcherV1(BaseModuleDispatcher):
             else:
                 ansible.utils.module_finder.add_directory(paths)
 
-        return ansible.utils.module_finder.has_plugin(name)
+        return module_finder.has_plugin(name)
 
     def _run(self, *module_args, **complex_args):
         """Execute an ansible adhoc command returning the results in a AdHocResult object."""

--- a/src/pytest_ansible/module_dispatcher/v2.py
+++ b/src/pytest_ansible/module_dispatcher/v2.py
@@ -10,6 +10,7 @@ from ansible.cli import CLI
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
+from ansible.plugins.loader import module_loader
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from pytest_ansible.has_version import has_ansible_v2
@@ -60,11 +61,11 @@ class ModuleDispatcherV2(BaseModuleDispatcher):
             paths = self.options["module_path"]
             if isinstance(paths, (list, tuple, set)):
                 for path in paths:
-                    ansible.plugins.module_loader.add_directory(path)
+                    module_loader.add_directory(path)
             else:
-                ansible.plugins.module_loader.add_directory(paths)
+                module_loader.add_directory(paths)
 
-        return ansible.plugins.module_loader.has_plugin(name)
+        return module_loader.has_plugin(name)
 
     def _run(self, *module_args, **complex_args):
         """Execute an ansible adhoc command returning the result in a AdhocResult object."""
@@ -88,6 +89,7 @@ class ModuleDispatcherV2(BaseModuleDispatcher):
                 "Specified hosts and/or --limit does not match any hosts",
             )
 
+        # pylint: disable=no-member
         parser = CLI.base_parser(
             runas_opts=True,
             inventory_opts=True,

--- a/src/pytest_ansible/module_dispatcher/v213.py
+++ b/src/pytest_ansible/module_dispatcher/v213.py
@@ -5,6 +5,7 @@ import ansible.constants
 import ansible.errors
 import ansible.utils
 from ansible.cli.adhoc import AdHocCLI
+from ansible.constants import COLLECTIONS_PATHS
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
@@ -205,7 +206,7 @@ class ModuleDispatcherV213(ModuleDispatcherV2):
 
         if HAS_CUSTOM_LOADER_SUPPORT:
             # Load the collection finder, unsupported, may change in future
-            init_plugin_loader(ansible.constants.COLLECTIONS_PATHS)
+            init_plugin_loader(COLLECTIONS_PATHS)
 
         # now create a task queue manager to execute the play
         tqm = None

--- a/src/pytest_ansible/module_dispatcher/v24.py
+++ b/src/pytest_ansible/module_dispatcher/v24.py
@@ -91,6 +91,7 @@ class ModuleDispatcherV24(ModuleDispatcherV2):
                 "Specified hosts and/or --limit does not match any hosts",
             )
 
+        # pylint: disable=no-member
         parser = CLI.base_parser(
             runas_opts=True,
             inventory_opts=True,

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -16,7 +16,7 @@ from pytest_ansible.fixtures import (
 from pytest_ansible.host_manager import get_host_manager
 
 # Silence linters for imported fixtures
-# pylint: disable=pointless-statement
+# pylint: disable=pointless-statement, no-member
 (ansible_adhoc, ansible_module, ansible_facts, localhost)
 
 


### PR DESCRIPTION
The `no-member` check ensures that you are accessing valid attributes and methods for the object's class. This error is mostly raised when we try to access an attribute or method that is not defined for the object's class.