### PR TITLE
Add `invalid-name` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,6 @@ disable = [
   "fixme",
   "import-error",
   "import-outside-toplevel",
-  "invalid-name",
   "missing-function-docstring",
   "missing-module-docstring",
   "no-name-in-module",

--- a/src/pytest_ansible/module_dispatcher/v2.py
+++ b/src/pytest_ansible/module_dispatcher/v2.py
@@ -114,14 +114,14 @@ class ModuleDispatcherV2(BaseModuleDispatcher):
         options.module_path = self.options.get("module_path")
 
         # Initialize callback to capture module JSON responses
-        cb = ResultAccumulator()
+        call_back = ResultAccumulator()
 
         kwargs = {
             "inventory": self.options["inventory_manager"],
             "variable_manager": self.options["variable_manager"],
             "loader": self.options["loader"],
             "options": options,
-            "stdout_callback": cb,
+            "stdout_callback": call_back,
             "passwords": {"conn_pass": None, "become_pass": None},
         }
 
@@ -157,12 +157,12 @@ class ModuleDispatcherV2(BaseModuleDispatcher):
 
         # Raise exception if host(s) unreachable
         # FIXME - if multiple hosts were involved, should an exception be raised?
-        if cb.unreachable:
+        if call_back.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable",
-                dark=cb.unreachable,
-                contacted=cb.contacted,
+                dark=call_back.unreachable,
+                contacted=call_back.contacted,
             )
 
         # Success!
-        return AdHocResult(contacted=cb.contacted)
+        return AdHocResult(contacted=call_back.contacted)

--- a/src/pytest_ansible/module_dispatcher/v2.py
+++ b/src/pytest_ansible/module_dispatcher/v2.py
@@ -114,14 +114,14 @@ class ModuleDispatcherV2(BaseModuleDispatcher):
         options.module_path = self.options.get("module_path")
 
         # Initialize callback to capture module JSON responses
-        call_back = ResultAccumulator()
+        callback = ResultAccumulator()
 
         kwargs = {
             "inventory": self.options["inventory_manager"],
             "variable_manager": self.options["variable_manager"],
             "loader": self.options["loader"],
             "options": options,
-            "stdout_callback": call_back,
+            "stdout_callback": callback,
             "passwords": {"conn_pass": None, "become_pass": None},
         }
 
@@ -157,12 +157,12 @@ class ModuleDispatcherV2(BaseModuleDispatcher):
 
         # Raise exception if host(s) unreachable
         # FIXME - if multiple hosts were involved, should an exception be raised?
-        if call_back.unreachable:
+        if callback.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable",
-                dark=call_back.unreachable,
-                contacted=call_back.contacted,
+                dark=callback.unreachable,
+                contacted=callback.contacted,
             )
 
         # Success!
-        return AdHocResult(contacted=call_back.contacted)
+        return AdHocResult(contacted=callback.contacted)

--- a/src/pytest_ansible/module_dispatcher/v212.py
+++ b/src/pytest_ansible/module_dispatcher/v212.py
@@ -135,26 +135,26 @@ class ModuleDispatcherV212(ModuleDispatcherV2):
         del adhoc
 
         # Initialize callbacks to capture module JSON responses
-        call_back = ResultAccumulator()
+        callback = ResultAccumulator()
 
         kwargs = {
             "inventory": self.options["inventory_manager"],
             "variable_manager": self.options["variable_manager"],
             "loader": self.options["loader"],
-            "stdout_callback": call_back,
+            "stdout_callback": callback,
             "passwords": {"conn_pass": None, "become_pass": None},
         }
 
         kwargs_extra = {}
         # If we have an extra inventory, do the same that we did for the inventory
         if "extra_inventory_manager" in self.options:
-            call_back_extra = ResultAccumulator()
+            callback_extra = ResultAccumulator()
 
             kwargs_extra = {
                 "inventory": self.options["extra_inventory_manager"],
                 "variable_manager": self.options["extra_variable_manager"],
                 "loader": self.options["extra_loader"],
-                "stdout_callback": call_back_extra,
+                "stdout_callback": callback_extra,
                 "passwords": {"conn_pass": None, "become_pass": None},
             }
 
@@ -209,24 +209,24 @@ class ModuleDispatcherV212(ModuleDispatcherV2):
 
         # Raise exception if host(s) unreachable
         # FIXME - if multiple hosts were involved, should an exception be raised?
-        if call_back.unreachable:
+        if callback.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable in the inventory",
-                dark=call_back.unreachable,
-                contacted=call_back.contacted,
+                dark=callback.unreachable,
+                contacted=callback.contacted,
             )
-        if "extra_inventory_manager" in self.options and call_back_extra.unreachable:
+        if "extra_inventory_manager" in self.options and callback_extra.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable in the extra inventory",
-                dark=call_back_extra.unreachable,
-                contacted=call_back_extra.contacted,
+                dark=callback_extra.unreachable,
+                contacted=callback_extra.contacted,
             )
 
         # Success!
         return AdHocResult(
             contacted=(
-                {**call_back.contacted, **call_back_extra.contacted}
+                {**callback.contacted, **callback_extra.contacted}
                 if "extra_inventory_manager" in self.options
-                else call_back.contacted
+                else callback.contacted
             ),
         )

--- a/src/pytest_ansible/module_dispatcher/v212.py
+++ b/src/pytest_ansible/module_dispatcher/v212.py
@@ -135,26 +135,26 @@ class ModuleDispatcherV212(ModuleDispatcherV2):
         del adhoc
 
         # Initialize callbacks to capture module JSON responses
-        cb = ResultAccumulator()
+        call_back = ResultAccumulator()
 
         kwargs = {
             "inventory": self.options["inventory_manager"],
             "variable_manager": self.options["variable_manager"],
             "loader": self.options["loader"],
-            "stdout_callback": cb,
+            "stdout_callback": call_back,
             "passwords": {"conn_pass": None, "become_pass": None},
         }
 
         kwargs_extra = {}
         # If we have an extra inventory, do the same that we did for the inventory
         if "extra_inventory_manager" in self.options:
-            cb_extra = ResultAccumulator()
+            call_back_extra = ResultAccumulator()
 
             kwargs_extra = {
                 "inventory": self.options["extra_inventory_manager"],
                 "variable_manager": self.options["extra_variable_manager"],
                 "loader": self.options["extra_loader"],
-                "stdout_callback": cb_extra,
+                "stdout_callback": call_back_extra,
                 "passwords": {"conn_pass": None, "become_pass": None},
             }
 
@@ -209,24 +209,24 @@ class ModuleDispatcherV212(ModuleDispatcherV2):
 
         # Raise exception if host(s) unreachable
         # FIXME - if multiple hosts were involved, should an exception be raised?
-        if cb.unreachable:
+        if call_back.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable in the inventory",
-                dark=cb.unreachable,
-                contacted=cb.contacted,
+                dark=call_back.unreachable,
+                contacted=call_back.contacted,
             )
-        if "extra_inventory_manager" in self.options and cb_extra.unreachable:
+        if "extra_inventory_manager" in self.options and call_back_extra.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable in the extra inventory",
-                dark=cb_extra.unreachable,
-                contacted=cb_extra.contacted,
+                dark=call_back_extra.unreachable,
+                contacted=call_back_extra.contacted,
             )
 
         # Success!
         return AdHocResult(
             contacted=(
-                {**cb.contacted, **cb_extra.contacted}
+                {**call_back.contacted, **call_back_extra.contacted}
                 if "extra_inventory_manager" in self.options
-                else cb.contacted
+                else call_back.contacted
             ),
         )

--- a/src/pytest_ansible/module_dispatcher/v213.py
+++ b/src/pytest_ansible/module_dispatcher/v213.py
@@ -151,26 +151,26 @@ class ModuleDispatcherV213(ModuleDispatcherV2):
         del adhoc
 
         # Initialize callbacks to capture module JSON responses
-        call_back = ResultAccumulator()
+        callback = ResultAccumulator()
 
         kwargs = {
             "inventory": self.options["inventory_manager"],
             "variable_manager": self.options["variable_manager"],
             "loader": self.options["loader"],
-            "stdout_callback": call_back,
+            "stdout_callback": callback,
             "passwords": {"conn_pass": None, "become_pass": None},
         }
 
         kwargs_extra = {}
         # If we have an extra inventory, do the same that we did for the inventory
         if "extra_inventory_manager" in self.options:
-            call_back_extra = ResultAccumulator()
+            callback_extra = ResultAccumulator()
 
             kwargs_extra = {
                 "inventory": self.options["extra_inventory_manager"],
                 "variable_manager": self.options["extra_variable_manager"],
                 "loader": self.options["extra_loader"],
-                "stdout_callback": call_back_extra,
+                "stdout_callback": callback_extra,
                 "passwords": {"conn_pass": None, "become_pass": None},
             }
 
@@ -228,24 +228,24 @@ class ModuleDispatcherV213(ModuleDispatcherV2):
 
         # Raise exception if host(s) unreachable
         # FIXME - if multiple hosts were involved, should an exception be raised?
-        if call_back.unreachable:
+        if callback.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable in the inventory",
-                dark=call_back.unreachable,
-                contacted=call_back.contacted,
+                dark=callback.unreachable,
+                contacted=callback.contacted,
             )
-        if "extra_inventory_manager" in self.options and call_back_extra.unreachable:
+        if "extra_inventory_manager" in self.options and callback_extra.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable in the extra inventory",
-                dark=call_back_extra.unreachable,
-                contacted=call_back_extra.contacted,
+                dark=callback_extra.unreachable,
+                contacted=callback_extra.contacted,
             )
 
         # Success!
         return AdHocResult(
             contacted=(
-                {**call_back.contacted, **call_back_extra.contacted}
+                {**callback.contacted, **callback_extra.contacted}
                 if "extra_inventory_manager" in self.options
-                else call_back.contacted
+                else callback.contacted
             ),
         )

--- a/src/pytest_ansible/module_dispatcher/v213.py
+++ b/src/pytest_ansible/module_dispatcher/v213.py
@@ -151,26 +151,26 @@ class ModuleDispatcherV213(ModuleDispatcherV2):
         del adhoc
 
         # Initialize callbacks to capture module JSON responses
-        cb = ResultAccumulator()
+        call_back = ResultAccumulator()
 
         kwargs = {
             "inventory": self.options["inventory_manager"],
             "variable_manager": self.options["variable_manager"],
             "loader": self.options["loader"],
-            "stdout_callback": cb,
+            "stdout_callback": call_back,
             "passwords": {"conn_pass": None, "become_pass": None},
         }
 
         kwargs_extra = {}
         # If we have an extra inventory, do the same that we did for the inventory
         if "extra_inventory_manager" in self.options:
-            cb_extra = ResultAccumulator()
+            call_back_extra = ResultAccumulator()
 
             kwargs_extra = {
                 "inventory": self.options["extra_inventory_manager"],
                 "variable_manager": self.options["extra_variable_manager"],
                 "loader": self.options["extra_loader"],
-                "stdout_callback": cb_extra,
+                "stdout_callback": call_back_extra,
                 "passwords": {"conn_pass": None, "become_pass": None},
             }
 
@@ -228,24 +228,24 @@ class ModuleDispatcherV213(ModuleDispatcherV2):
 
         # Raise exception if host(s) unreachable
         # FIXME - if multiple hosts were involved, should an exception be raised?
-        if cb.unreachable:
+        if call_back.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable in the inventory",
-                dark=cb.unreachable,
-                contacted=cb.contacted,
+                dark=call_back.unreachable,
+                contacted=call_back.contacted,
             )
-        if "extra_inventory_manager" in self.options and cb_extra.unreachable:
+        if "extra_inventory_manager" in self.options and call_back_extra.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable in the extra inventory",
-                dark=cb_extra.unreachable,
-                contacted=cb_extra.contacted,
+                dark=call_back_extra.unreachable,
+                contacted=call_back_extra.contacted,
             )
 
         # Success!
         return AdHocResult(
             contacted=(
-                {**cb.contacted, **cb_extra.contacted}
+                {**call_back.contacted, **call_back_extra.contacted}
                 if "extra_inventory_manager" in self.options
-                else cb.contacted
+                else call_back.contacted
             ),
         )

--- a/src/pytest_ansible/module_dispatcher/v24.py
+++ b/src/pytest_ansible/module_dispatcher/v24.py
@@ -116,14 +116,14 @@ class ModuleDispatcherV24(ModuleDispatcherV2):
         options.module_path = self.options.get("module_path")
 
         # Initialize callback to capture module JSON responses
-        call_back = ResultAccumulator()
+        callback = ResultAccumulator()
 
         kwargs = {
             "inventory": self.options["inventory_manager"],
             "variable_manager": self.options["variable_manager"],
             "loader": self.options["loader"],
             "options": options,
-            "stdout_callback": call_back,
+            "stdout_callback": callback,
             "passwords": {"conn_pass": None, "become_pass": None},
         }
 
@@ -159,12 +159,12 @@ class ModuleDispatcherV24(ModuleDispatcherV2):
 
         # Raise exception if host(s) unreachable
         # FIXME - if multiple hosts were involved, should an exception be raised?
-        if call_back.unreachable:
+        if callback.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable",
-                dark=call_back.unreachable,
-                contacted=call_back.contacted,
+                dark=callback.unreachable,
+                contacted=callback.contacted,
             )
 
         # Success!
-        return AdHocResult(contacted=call_back.contacted)
+        return AdHocResult(contacted=callback.contacted)

--- a/src/pytest_ansible/module_dispatcher/v24.py
+++ b/src/pytest_ansible/module_dispatcher/v24.py
@@ -116,14 +116,14 @@ class ModuleDispatcherV24(ModuleDispatcherV2):
         options.module_path = self.options.get("module_path")
 
         # Initialize callback to capture module JSON responses
-        cb = ResultAccumulator()
+        call_back = ResultAccumulator()
 
         kwargs = {
             "inventory": self.options["inventory_manager"],
             "variable_manager": self.options["variable_manager"],
             "loader": self.options["loader"],
             "options": options,
-            "stdout_callback": cb,
+            "stdout_callback": call_back,
             "passwords": {"conn_pass": None, "become_pass": None},
         }
 
@@ -159,12 +159,12 @@ class ModuleDispatcherV24(ModuleDispatcherV2):
 
         # Raise exception if host(s) unreachable
         # FIXME - if multiple hosts were involved, should an exception be raised?
-        if cb.unreachable:
+        if call_back.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable",
-                dark=cb.unreachable,
-                contacted=cb.contacted,
+                dark=call_back.unreachable,
+                contacted=call_back.contacted,
             )
 
         # Success!
-        return AdHocResult(contacted=cb.contacted)
+        return AdHocResult(contacted=call_back.contacted)

--- a/src/pytest_ansible/module_dispatcher/v28.py
+++ b/src/pytest_ansible/module_dispatcher/v28.py
@@ -132,13 +132,13 @@ class ModuleDispatcherV28(ModuleDispatcherV2):
         del adhoc
 
         # Initialize callback to capture module JSON responses
-        cb = ResultAccumulator()
+        call_back = ResultAccumulator()
 
         kwargs = {
             "inventory": self.options["inventory_manager"],
             "variable_manager": self.options["variable_manager"],
             "loader": self.options["loader"],
-            "stdout_callback": cb,
+            "stdout_callback": call_back,
             "passwords": {"conn_pass": None, "become_pass": None},
         }
 
@@ -176,12 +176,12 @@ class ModuleDispatcherV28(ModuleDispatcherV2):
 
         # Raise exception if host(s) unreachable
         # FIXME - if multiple hosts were involved, should an exception be raised?
-        if cb.unreachable:
+        if call_back.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable",
-                dark=cb.unreachable,
-                contacted=cb.contacted,
+                dark=call_back.unreachable,
+                contacted=call_back.contacted,
             )
 
         # Success!
-        return AdHocResult(contacted=cb.contacted)
+        return AdHocResult(contacted=call_back.contacted)

--- a/src/pytest_ansible/module_dispatcher/v28.py
+++ b/src/pytest_ansible/module_dispatcher/v28.py
@@ -132,13 +132,13 @@ class ModuleDispatcherV28(ModuleDispatcherV2):
         del adhoc
 
         # Initialize callback to capture module JSON responses
-        call_back = ResultAccumulator()
+        callback = ResultAccumulator()
 
         kwargs = {
             "inventory": self.options["inventory_manager"],
             "variable_manager": self.options["variable_manager"],
             "loader": self.options["loader"],
-            "stdout_callback": call_back,
+            "stdout_callback": callback,
             "passwords": {"conn_pass": None, "become_pass": None},
         }
 
@@ -176,12 +176,12 @@ class ModuleDispatcherV28(ModuleDispatcherV2):
 
         # Raise exception if host(s) unreachable
         # FIXME - if multiple hosts were involved, should an exception be raised?
-        if call_back.unreachable:
+        if callback.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable",
-                dark=call_back.unreachable,
-                contacted=call_back.contacted,
+                dark=callback.unreachable,
+                contacted=callback.contacted,
             )
 
         # Success!
-        return AdHocResult(contacted=call_back.contacted)
+        return AdHocResult(contacted=callback.contacted)

--- a/src/pytest_ansible/module_dispatcher/v29.py
+++ b/src/pytest_ansible/module_dispatcher/v29.py
@@ -133,26 +133,26 @@ class ModuleDispatcherV29(ModuleDispatcherV2):
         del adhoc
 
         # Initialize callbacks to capture module JSON responses
-        cb = ResultAccumulator()
+        call_back = ResultAccumulator()
 
         kwargs = {
             "inventory": self.options["inventory_manager"],
             "variable_manager": self.options["variable_manager"],
             "loader": self.options["loader"],
-            "stdout_callback": cb,
+            "stdout_callback": call_back,
             "passwords": {"conn_pass": None, "become_pass": None},
         }
 
         kwargs_extra = {}
         # If we have an extra inventory, do the same that we did for the inventory
         if "extra_inventory_manager" in self.options:
-            cb_extra = ResultAccumulator()
+            call_back_extra = ResultAccumulator()
 
             kwargs_extra = {
                 "inventory": self.options["extra_inventory_manager"],
                 "variable_manager": self.options["extra_variable_manager"],
                 "loader": self.options["extra_loader"],
-                "stdout_callback": cb_extra,
+                "stdout_callback": call_back_extra,
                 "passwords": {"conn_pass": None, "become_pass": None},
             }
 
@@ -206,24 +206,24 @@ class ModuleDispatcherV29(ModuleDispatcherV2):
 
         # Raise exception if host(s) unreachable
         # FIXME - if multiple hosts were involved, should an exception be raised?
-        if cb.unreachable:
+        if call_back.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable in the inventory",
-                dark=cb.unreachable,
-                contacted=cb.contacted,
+                dark=call_back.unreachable,
+                contacted=call_back.contacted,
             )
-        if "extra_inventory_manager" in self.options and cb_extra.unreachable:
+        if "extra_inventory_manager" in self.options and call_back_extra.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable in the extra inventory",
-                dark=cb_extra.unreachable,
-                contacted=cb_extra.contacted,
+                dark=call_back_extra.unreachable,
+                contacted=call_back_extra.contacted,
             )
 
         # Success!
         return AdHocResult(
             contacted=(
-                {**cb.contacted, **cb_extra.contacted}
+                {**call_back.contacted, **call_back_extra.contacted}
                 if "extra_inventory_manager" in self.options
-                else cb.contacted
+                else call_back.contacted
             ),
         )

--- a/src/pytest_ansible/module_dispatcher/v29.py
+++ b/src/pytest_ansible/module_dispatcher/v29.py
@@ -133,26 +133,26 @@ class ModuleDispatcherV29(ModuleDispatcherV2):
         del adhoc
 
         # Initialize callbacks to capture module JSON responses
-        call_back = ResultAccumulator()
+        callback = ResultAccumulator()
 
         kwargs = {
             "inventory": self.options["inventory_manager"],
             "variable_manager": self.options["variable_manager"],
             "loader": self.options["loader"],
-            "stdout_callback": call_back,
+            "stdout_callback": callback,
             "passwords": {"conn_pass": None, "become_pass": None},
         }
 
         kwargs_extra = {}
         # If we have an extra inventory, do the same that we did for the inventory
         if "extra_inventory_manager" in self.options:
-            call_back_extra = ResultAccumulator()
+            callback_extra = ResultAccumulator()
 
             kwargs_extra = {
                 "inventory": self.options["extra_inventory_manager"],
                 "variable_manager": self.options["extra_variable_manager"],
                 "loader": self.options["extra_loader"],
-                "stdout_callback": call_back_extra,
+                "stdout_callback": callback_extra,
                 "passwords": {"conn_pass": None, "become_pass": None},
             }
 
@@ -206,24 +206,24 @@ class ModuleDispatcherV29(ModuleDispatcherV2):
 
         # Raise exception if host(s) unreachable
         # FIXME - if multiple hosts were involved, should an exception be raised?
-        if call_back.unreachable:
+        if callback.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable in the inventory",
-                dark=call_back.unreachable,
-                contacted=call_back.contacted,
+                dark=callback.unreachable,
+                contacted=callback.contacted,
             )
-        if "extra_inventory_manager" in self.options and call_back_extra.unreachable:
+        if "extra_inventory_manager" in self.options and callback_extra.unreachable:
             raise AnsibleConnectionFailure(
                 "Host unreachable in the extra inventory",
-                dark=call_back_extra.unreachable,
-                contacted=call_back_extra.contacted,
+                dark=callback_extra.unreachable,
+                contacted=callback_extra.contacted,
             )
 
         # Success!
         return AdHocResult(
             contacted=(
-                {**call_back.contacted, **call_back_extra.contacted}
+                {**callback.contacted, **callback_extra.contacted}
                 if "extra_inventory_manager" in self.options
-                else call_back.contacted
+                else callback.contacted
             ),
         )

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -166,8 +166,8 @@ def pytest_generate_tests(metafunc):
                 config=plugin.config,
                 pattern=metafunc.config.getoption("ansible_host_pattern"),
             )
-        except ansible.errors.AnsibleError as e:
-            raise pytest.UsageError(e)
+        except ansible.errors.AnsibleError as exception:
+            raise pytest.UsageError(exception)
         # Return the host name as a string
         # Return a HostManager instance where pattern=host (e.g. ansible_host.all.shell('date'))
         # metafunc.parametrize("ansible_host", iter(plugin.initialize(config=plugin.config, pattern=h) for h in
@@ -184,8 +184,8 @@ def pytest_generate_tests(metafunc):
                 config=plugin.config,
                 pattern=metafunc.config.getoption("ansible_host_pattern"),
             )
-        except ansible.errors.AnsibleError as e:
-            raise pytest.UsageError(e)
+        except ansible.errors.AnsibleError as exception:
+            raise pytest.UsageError(exception)
         # FIXME: Eeew, this shouldn't be interfacing with `hosts.options`
         groups = hosts.options["inventory_manager"].list_groups()
         extra_groups = hosts.get_extra_inventory_groups()


### PR DESCRIPTION
The `invalid-name` rule ensures that the variables declared are following the correct naming convention like `small_case`. This makes our code more readable and maintainable.