### PR TITLE
ruff: Address `TCH` rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,6 @@ ignore = [
   "S",
   "SLF",
   "T",
-  "TCH",
   "TRY",
 ]
 target-version = "py39"

--- a/src/pytest_ansible/module_dispatcher/v2.py
+++ b/src/pytest_ansible/module_dispatcher/v2.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import ansible.constants
 import ansible.errors
@@ -45,6 +45,9 @@ class ResultAccumulator(CallbackBase):
 
 class ModuleDispatcherV2(BaseModuleDispatcher):
     """Pass."""
+
+    if TYPE_CHECKING:
+        from collections.abc import Sequence
 
     required_kwargs: Sequence[str] = (
         "inventory",

--- a/src/pytest_ansible/module_dispatcher/v212.py
+++ b/src/pytest_ansible/module_dispatcher/v212.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 import warnings
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import ansible.constants
 import ansible.errors
@@ -53,6 +53,9 @@ class ResultAccumulator(CallbackBase):
 
 class ModuleDispatcherV212(ModuleDispatcherV2):
     """Pass."""
+
+    if TYPE_CHECKING:
+        from collections.abc import Sequence
 
     required_kwargs: Sequence[str] = (
         "inventory",


### PR DESCRIPTION
The `TCH` check suggests to move the import defined at top-level into a type-checking block and ensures to avoid importing unnecessary modules at runtime, while still providing type hints to our code.