### PR TITLE
feature integrate `pytest-ansible-units`

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -1,0 +1,9 @@
+argparsing
+cidrblock
+filterwarnings
+pathsep
+pytest
+startpath
+testpaths
+udring
+addoption

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ changelog = "https://github.com/ansible-community/pytest-ansible/releases"
 
 [tool.mypy]
 python_version = 3.9
+ignore_missing_imports = true
+ignore_errors = true
 # strict = true
 color_output = true
 error_summary = true
@@ -88,6 +90,7 @@ disable = [
   "too-many-statements",
   "unexpected-keyword-arg",
   "unused-argument",
+  "invalid-name",
 ]
 
 [tool.pytest]
@@ -126,6 +129,8 @@ ignore = [
   "SLF",
   "T",
   "TRY",
+  "PTH",
+  "TCH",
 ]
 target-version = "py39"
 # Same as Black.

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -134,6 +134,18 @@ def pytest_addoption(parser):
         help="ask for privilege escalation password (default: %(default)s)",
     )
 
+    parser.addoption(
+        "--unit",
+        action="store_true",
+        default=False,
+        help="Run only the unit tests",
+    )
+    parser.addoption(
+        "--unit-inject-only",
+        action="store_true",
+        default=False,
+        help="Run only the unit tests and inject fixtures",
+    )
     # Add github marker to --help
     parser.addini("ansible", "Ansible integration", "args")
 
@@ -151,6 +163,9 @@ def pytest_configure(config):
 
             display = Display()
             display.verbosity = int(config.option.verbose)
+    if config.option.unit or config.option.unit_inject_only:
+        # Run the unit tests
+        pytest.main(["--pytest-ansible-unit"])
 
     assert config.pluginmanager.register(PyTestAnsiblePlugin(config), "ansible")
 

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -18,7 +18,7 @@ from pytest_ansible.fixtures import (
 )
 from pytest_ansible.host_manager import get_host_manager
 
-from .units import inject
+from .units import inject, inject_only
 
 logger = logging.getLogger(__name__)
 
@@ -181,11 +181,13 @@ def pytest_configure(config):
     logging.basicConfig(level=level)
     logging.debug("Logging initialized")
 
-    if config.option.unit or config.option.unit_inject_only:
+    assert config.pluginmanager.register(PyTestAnsiblePlugin(config), "ansible")
+
+    if config.option.unit_inject_only:
+        inject_only()
+    else:
         start_path = config.invocation_params.dir
         inject(start_path)
-
-    assert config.pluginmanager.register(PyTestAnsiblePlugin(config), "ansible")
 
 
 def pytest_generate_tests(metafunc):

--- a/src/pytest_ansible/units.py
+++ b/src/pytest_ansible/units.py
@@ -6,9 +6,6 @@ import os
 import sys
 from pathlib import Path
 
-import pytest
-from _pytest.config.argparsing import Parser
-
 logger = logging.getLogger(__name__)
 
 try:
@@ -31,42 +28,6 @@ try:
     HAS_COLLECTION_FINDER = True
 except ImportError:
     HAS_COLLECTION_FINDER = False
-
-
-def pytest_addoption(parser: Parser) -> None:
-    """Add the options to the pytest command.
-
-    :param parser: The pytest parser object
-    """
-    parser.addoption(
-        "--inject-only",
-        action="store_true",
-        default=False,
-        help="Only inject the current ANSIBLE_COLLECTIONS_PATHS",
-    )
-
-
-def pytest_configure(config: pytest.Config) -> None:
-    """Configure the logger.
-
-    :param config: The pytest configuration object
-    """
-    log_map = {
-        0: logging.CRITICAL,
-        1: logging.ERROR,
-        2: logging.WARNING,
-        3: logging.INFO,
-        4: logging.DEBUG,
-    }
-    level = log_map.get(config.option.verbose)
-    logging.basicConfig(level=level)
-    logger.debug("Logging initialized")
-    if config.option.inject_only:
-        inject_only()
-    else:
-        inject(config.invocation_params.dir)
-    if config.getoption("--unit") or config.getoption("--unit-inject-only"):
-        pass
 
 
 def get_collection_name(start_path: Path) -> tuple[str | None, str | None]:

--- a/src/pytest_ansible_units/__init__.py
+++ b/src/pytest_ansible_units/__init__.py
@@ -1,0 +1,177 @@
+"""Setup the collection for testing."""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from _pytest.config.argparsing import Parser
+
+logger = logging.getLogger(__name__)
+
+try:
+    import yaml
+
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
+
+try:
+    HAS_ANSIBLE = True
+except ImportError:
+    HAS_ANSIBLE = False
+
+try:
+    from ansible.utils.collection_loader._collection_finder import (
+        _AnsibleCollectionFinder,
+    )
+
+    HAS_COLLECTION_FINDER = True
+except ImportError:
+    HAS_COLLECTION_FINDER = False
+
+
+def pytest_addoption(parser: Parser) -> None:
+    """Add the options to the pytest command.
+
+    :param parser: The pytest parser object
+    """
+    parser.addoption(
+        "--inject-only",
+        action="store_true",
+        default=False,
+        help="Only inject the current ANSIBLE_COLLECTIONS_PATHS",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Configure the logger.
+
+    :param config: The pytest configuration object
+    """
+    log_map = {
+        0: logging.CRITICAL,
+        1: logging.ERROR,
+        2: logging.WARNING,
+        3: logging.INFO,
+        4: logging.DEBUG,
+    }
+    level = log_map.get(config.option.verbose)
+    logging.basicConfig(level=level)
+    logger.debug("Logging initialized")
+    if config.option.inject_only:
+        inject_only()
+    else:
+        inject(config.invocation_params.dir)
+    if config.getoption("--unit") or config.getoption("--unit-inject-only"):
+        pass
+
+
+def get_collection_name(start_path: Path) -> tuple[str | None, str | None]:
+    """Get the collection namespace and name from the galaxy.yml file.
+
+    :param start_path: The path to the root of the collection
+    :returns: A tuple of the namespace and name
+    """
+    info_file = start_path / "galaxy.yml"
+    logger.info("Looking for collection info in %s", info_file)
+
+    try:
+        with info_file.open(encoding="utf-8") as fh:
+            galaxy_info = yaml.safe_load(fh)
+    except FileNotFoundError:
+        logger.error("No galaxy.yml file found, plugin not activated")
+        return None, None
+
+    try:
+        namespace = galaxy_info["namespace"]
+        name = galaxy_info["name"]
+    except KeyError:
+        logger.error("galaxy.yml file does not contain namespace and name")
+        return None, None
+
+    logger.debug("galaxy.yml file found, plugin activated")
+    logger.info("Collection namespace: %s", namespace)
+    logger.info("Collection name: %s", name)
+    return namespace, name
+
+
+def inject(start_path: Path) -> None:
+    """Inject the collection path.
+
+    In the case of ansible > 2.9, initialize the collection finder with the collection path
+    otherwise, inject the collection path into sys.path.
+
+    :param start_path: The path where pytest was invoked
+    """
+    if not HAS_ANSIBLE:
+        logger.error("ansible is not installed, plugin not activated")
+        return
+    if not HAS_YAML:
+        logger.error("pyyaml is not installed, plugin not activated")
+        return
+
+    logger.debug("Start path: %s", start_path)
+    namespace, name = get_collection_name(start_path)
+    if namespace is None or name is None:
+        # Tests may not being run from the root of the repo.
+        return
+
+    # Determine if the start_path is in a collections tree
+    collection_tree = ("collections", "ansible_collections", namespace, name)
+    if start_path.parts[-4:] == collection_tree:
+        logger.info("In collection tree")
+        collections_dir = start_path.parents[2]
+
+    else:
+        logger.info("Not in collection tree")
+        collections_dir = start_path / "collections"
+        name_dir = collections_dir / "ansible_collections" / namespace / name
+
+        # If it's here, we will trust it was from this
+        if not name_dir.is_dir():
+            os.makedirs(name_dir, exist_ok=True)
+
+            for entry in start_path.iterdir():
+                if entry.name == "collections":
+                    continue
+                os.symlink(entry, name_dir / entry.name)
+
+    logger.info("Collections dir: %s", collections_dir)
+
+    # TODO: Make this a configuration option, check COLLECTIONS_PATHS
+    # Add the user location for any dependencies
+    paths = [str(collections_dir), "~/.ansible/collections"]
+    logger.info("Paths: %s", paths)
+
+    if HAS_COLLECTION_FINDER:
+        # pylint: disable=protected-access
+        _AnsibleCollectionFinder(paths=paths)._install()
+
+    # Inject the path for the collection into sys.path
+    # This is needed for import udring mock tests
+    sys.path.insert(0, str(collections_dir))
+    logger.debug("sys.path updated: %s", sys.path)
+
+    # TODO: Should we install any collection dependencies as well?
+    # or let the developer do that?
+    # e.g. ansible-galaxy collection install etc
+
+    # Set the environment variable as courtesy for integration tests
+    env_paths = os.pathsep.join(paths)
+    logger.info("Setting ANSIBLE_COLLECTIONS_PATH to %s", env_paths)
+    os.environ["ANSIBLE_COLLECTIONS_PATHS"] = env_paths
+
+
+def inject_only() -> None:
+    """Inject the current ANSIBLE_COLLECTIONS_PATHS."""
+    env_paths = os.environ.get("ANSIBLE_COLLECTIONS_PATHS", "")
+    for path in env_paths.split(os.pathsep):
+        if path:
+            sys.path.insert(0, path)
+    logger.debug("sys.path updated: %s", sys.path)
+    if HAS_COLLECTION_FINDER:
+        # pylint: disable=protected-access
+        _AnsibleCollectionFinder(paths=env_paths)._install()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ except ImportError:
     co = None
 
 
-pytest_plugins = ["pytester", "pytest_ansible_units"]
+pytest_plugins = ["pytester"]
 
 
 ALL_HOSTS = ["another_host", "localhost", "yet_another_host"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ except ImportError:
     co = None
 
 
-pytest_plugins = ("pytester",)
+pytest_plugins = ["pytester", "pytest_ansible_units"]
 
 
 ALL_HOSTS = ["another_host", "localhost", "yet_another_host"]


### PR DESCRIPTION
#70 #73 [#13](https://github.com/ansible-community/pytest-ansible-units/issues/13)

Added the pytest-ansible-units code in a new folder inside `src/pytest_ansible_units` and introducing command line args `--unit ` & `--unit-inject-only` that tirggers the `pytest-ansible-unit` plugin and since the work is in progress, created a draft PR as I wanted some suggestions on it.