### PR TITLE
Enable unit test support by default

### DIFF
--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -140,18 +140,11 @@ def pytest_addoption(parser):
         default=ansible.constants.DEFAULT_BECOME_ASK_PASS,
         help="ask for privilege escalation password (default: %(default)s)",
     )
-
-    group.addoption(
-        "--ansible-unit",
-        action="store_true",
-        default=False,
-        help="Enable support for ansible collection unit tests, inject paths and build the collection tree if needed.",
-    )
     group.addoption(
         "--ansible-unit-inject-only",
         action="store_true",
         default=False,
-        help="Enable support for ansible collection unit tests, only inject exisiting ANSIBLE_COLLECTIONS_PATHS.",
+        help="Enable support for ansible collection unit tests by only injecting exisiting ANSIBLE_COLLECTIONS_PATHS.",
     )
     # Add github marker to --help
     parser.addini("ansible", "Ansible integration", "args")
@@ -177,7 +170,7 @@ def pytest_configure(config):
 
     if config.option.ansible_unit_inject_only:
         inject_only()
-    elif config.option.ansible_unit:
+    else:
         start_path = config.invocation_params.dir
         inject(start_path)
 

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -8,7 +8,6 @@ import sys
 from pathlib import Path
 
 import pytest
-
 from pytest_ansible.units import inject, inject_only
 
 

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 import pytest
+
 from pytest_ansible.units import inject, inject_only
 
 
@@ -79,5 +80,4 @@ def test_inject_only(
 def test_for_params():
     """Test for params."""
     proc = subprocess.run("pytest --help", shell=True, capture_output=True, check=False)
-    assert "--ansible-unit" in proc.stdout.decode()
     assert "--ansible-unit-inject-only" in proc.stdout.decode()


### PR DESCRIPTION
Rather than require the user to enable unit test support, enable it by default if a galaxy.yml file is found in the root of the project.

Related #114 