### PR TITLE
Switch to ANSIBLE_COLLECTION_PATH

### DIFF
--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -144,7 +144,7 @@ def pytest_addoption(parser):
         "--ansible-unit-inject-only",
         action="store_true",
         default=False,
-        help="Enable support for ansible collection unit tests by only injecting exisiting ANSIBLE_COLLECTIONS_PATHS.",
+        help="Enable support for ansible collection unit tests by only injecting exisiting ANSIBLE_COLLECTIONS_PATH.",
     )
     # Add github marker to --help
     parser.addini("ansible", "Ansible integration", "args")

--- a/src/pytest_ansible/units.py
+++ b/src/pytest_ansible/units.py
@@ -102,7 +102,7 @@ def inject(start_path: Path) -> None:
 
     logger.info("Collections dir: %s", collections_dir)
 
-    # TODO: Make this a configuration option, check COLLECTIONS_PATHS
+    # TODO: Make this a configuration option, check COLLECTIONS_PATH
     # Add the user location for any dependencies
     paths = [str(collections_dir), "~/.ansible/collections"]
     logger.info("Paths: %s", paths)
@@ -121,12 +121,12 @@ def inject(start_path: Path) -> None:
     # Set the environment variable as courtesy for integration tests
     env_paths = os.pathsep.join(paths)
     logger.info("Setting ANSIBLE_COLLECTIONS_PATH to %s", env_paths)
-    os.environ["ANSIBLE_COLLECTIONS_PATHS"] = env_paths
+    os.environ["ANSIBLE_COLLECTIONS_PATH"] = env_paths
 
 
 def inject_only() -> None:
-    """Inject the current ANSIBLE_COLLECTIONS_PATHS."""
-    env_paths = os.environ.get("ANSIBLE_COLLECTIONS_PATHS", "")
+    """Inject the current ANSIBLE_COLLECTIONS_PATH."""
+    env_paths = os.environ.get("ANSIBLE_COLLECTIONS_PATH", "")
     path_list = env_paths.split(os.pathsep)
     for path in path_list:
         if path:

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -64,7 +64,7 @@ def test_inject_only(
     :param caplog: The pytest caplog fixture
     """
     caplog.set_level(logging.DEBUG)
-    monkeypatch.setenv("ANSIBLE_COLLECTIONS_PATHS", str(tmp_path / "collections"))
+    monkeypatch.setenv("ANSIBLE_COLLECTIONS_PATH", str(tmp_path / "collections"))
 
     (tmp_path / "collections" / "ansible_collections").mkdir(parents=True)
 


### PR DESCRIPTION
Related: https://github.com/tox-dev/tox-ansible/pull/196

devel has deprecated the plural:

```
[DEPRECATION WARNING]: ANSIBLE_COLLECTIONS_PATHS option, does not fit var 
naming standard, use the singular form ANSIBLE_COLLECTIONS_PATH instead. This 
feature will be removed from ansible-core in version 2.19. Deprecation warnings
 can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

Since the tox-ansible plugin is inject the singular, we need the same ehre to be picked up and injected.

Otherwise, the 2 are incompatible and result in these errors.

https://github.com/ansible-collections/ansible.scm/actions/runs/5727484046/job/15520195428?pr=224