### PR TITLE
Fix for ansible 2.9

### DIFF
--- a/src/pytest_ansible/units.py
+++ b/src/pytest_ansible/units.py
@@ -154,15 +154,14 @@ def acf_inject(paths: list[str]) -> None:
 
 
 def determine_envvar() -> str:
-    """Use the existance of the AnsibleCollectioFinder to determine
+    """Use the existence of the AnsibleCollectionFinder to determine
     the ansible version.
 
-        ansible 2.9 did not have AnsibleCollectionFinder and did not support ANSIBLE_COLLECTIONS_PATH
+    ansible 2.9 did not have AnsibleCollectionFinder and did not support ANSIBLE_COLLECTIONS_PATH
     later versions do.
 
     :returns: The appropriate environment variable to use
     """
     if not HAS_COLLECTION_FINDER:
         return "ANSIBLE_COLLECTIONS_PATHS"
-    else:
-        return "ANSIBLE_COLLECTIONS_PATH"
+    return "ANSIBLE_COLLECTIONS_PATH"

--- a/src/pytest_ansible/units.py
+++ b/src/pytest_ansible/units.py
@@ -119,14 +119,17 @@ def inject(start_path: Path) -> None:
     # e.g. ansible-galaxy collection install etc
 
     # Set the environment variable as courtesy for integration tests
+
+    envvar_name = determine_envvar()
     env_paths = os.pathsep.join(paths)
-    logger.info("Setting ANSIBLE_COLLECTIONS_PATH to %s", env_paths)
-    os.environ["ANSIBLE_COLLECTIONS_PATH"] = env_paths
+    logger.info("Setting %s to %s", envvar_name, env_paths)
+    os.environ[envvar_name] = env_paths
 
 
 def inject_only() -> None:
-    """Inject the current ANSIBLE_COLLECTIONS_PATH."""
-    env_paths = os.environ.get("ANSIBLE_COLLECTIONS_PATH", "")
+    """Inject the current ANSIBLE_COLLECTIONS_PATH(S)."""
+    envvar_name = determine_envvar()
+    env_paths = os.environ.get(envvar_name, "")
     path_list = env_paths.split(os.pathsep)
     for path in path_list:
         if path:
@@ -148,3 +151,18 @@ def acf_inject(paths: list[str]) -> None:
         logger.debug("_ACF configured paths: %s", acf._n_configured_paths)
     else:
         logger.debug("_ACF not available")
+
+
+def determine_envvar() -> str:
+    """Use the existance of the AnsibleCollectioFinder to determine
+    the ansible version.
+
+        ansible 2.9 did not have AnsibleCollectionFinder and did not support ANSIBLE_COLLECTIONS_PATH
+    later versions do.
+
+    :returns: The appropriate environment variable to use
+    """
+    if not HAS_COLLECTION_FINDER:
+        return "ANSIBLE_COLLECTIONS_PATHS"
+    else:
+        return "ANSIBLE_COLLECTIONS_PATH"


### PR DESCRIPTION
ansible 2.9 did not support `ANSIBLE_COLLECTIONS_PATH` so work around that.

This reverts #139 for ansible 2.9

Related is https://github.com/tox-dev/tox-ansible/pull/202