### PR TITLE
Update docs to extend support for `units` & `molecule` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,22 @@
 The `pytest-ansible` plugin is designed to provide seamless integration between `pytest` and `Ansible`, allowing you to efficiently run and test Ansible-related tasks and scenarios within your pytest test suite. This plugin enhances the testing workflow by offering three distinct pieces of functionality:
 
 1. **Unit Testing for Ansible Collections**:
-This feature aids in running unit tests for `Ansible collections` using `pytest`. It allows you to validate the behavior of your Ansible `modules` and `roles` in isolation, ensuring that each component functions as expected.
+   This feature aids in running unit tests for `Ansible collections` using `pytest`. It allows you to validate the behavior of your Ansible `modules` and `roles` in isolation, ensuring that each component functions as expected.
 
 2. **Molecule Scenario Integration**:
-The plugin assists in running Molecule `scenarios` using `pytest`. This integration streamlines the testing of Ansible roles and playbooks across different environments, making it easier to identify and fix issues across diverse setups.
+   The plugin assists in running Molecule `scenarios` using `pytest`. This integration streamlines the testing of Ansible roles and playbooks across different environments, making it easier to identify and fix issues across diverse setups.
 
 3. **Ansible Integration for Pytest Tests**:
-With this functionality, you can seamlessly use `Ansible` from within your `pytest` tests. This opens up possibilities to interact with Ansible components and perform tasks like provisioning resources, testing configurations, and more, all while leveraging the power and flexibility of pytest.
+   With this functionality, you can seamlessly use `Ansible` from within your `pytest` tests. This opens up possibilities to interact with Ansible components and perform tasks like provisioning resources, testing configurations, and more, all while leveraging the power and flexibility of pytest.
 
 ## Installation
+
 Install this plugin using `pip`:
+
 ```
 pip install pytest-ansible
 ```
+
 ## Getting Started
 
 ### Unit Testing for Ansible Collections
@@ -30,29 +33,35 @@ The `pytest-ansible-units` plugin allows ansible collection's unit tests to be r
 To use `pytest-ansible-units`, follow these steps:
 
 1. Install the plugin using pip:
+
 ```
 pip install pytest-ansible
 ```
+
 2. Ensure you have Python 3.8 or greater, ansible-core, and pyyaml installed.
 
 3. Depending on your preferred directory structure, you can clone collections into the appropriate paths.
 
-    - **Collection Tree Approach**: The preferred approach is to clone the collections being developed into it's proper collection tree path. This eliminates the need for any 
-      symlinks and other collections being developed can be cloned into the same tree structure.
-      ```
-      git clone <repo> collections/ansible_collections/<namespace>/<name>
-      ```
-      Note: Run `pytest` in the root of the collection directory, adjacent to the collection's `galaxy.yml` file.
+   - **Collection Tree Approach**: The preferred approach is to clone the collections being developed into it's proper collection tree path. This eliminates the need for any
+     symlinks and other collections being developed can be cloned into the same tree structure.
 
-     - **Shallow Tree Approach**:
-       ```
-       git clone <repo>
-       ```
-       Notes:
-       
-        - Run `pytest` in the root of the collection directory, adjacent to the collection's `galaxy.yml` file.
-        - A collections directory will be created in the repository directory, and collection content will be linked into it.
-   
+     ```
+     git clone <repo> collections/ansible_collections/<namespace>/<name>
+     ```
+
+     Note: Run `pytest` in the root of the collection directory, adjacent to the collection's `galaxy.yml` file.
+
+   - **Shallow Tree Approach**:
+
+     ```
+     git clone <repo>
+     ```
+
+     Notes:
+
+     - Run `pytest` in the root of the collection directory, adjacent to the collection's `galaxy.yml` file.
+     - A collections directory will be created in the repository directory, and collection content will be linked into it.
+
 4. Execute the unit tests using pytest: `pytest tests`
 
 ### Help
@@ -91,21 +100,24 @@ HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test
 ```
 
 ## Molecule Scenario Integration
+
 The `pytest-molecule` plugin enables pytest discovery of all `molecule.yml` files inside the codebase and runs them as pytest tests. It allows you to include Molecule scenarios as part of your pytest test suite, allowing you to thoroughly test your Ansible roles and playbooks across different scenarios and environments. Once you install `pytest-ansible`, you should be able to just run `pytest` to execute Molecule on all roles and scenarios.
 
 To run Molecule scenarios using pytest, follow these steps:
 
 1. Install the `pytest-ansible` plugin using pip:
+
 ```
 pip install pytest-ansible
 ```
+
 2. Execute pytest to run Molecule scenarios: `pytest`
 3. You can use markers and other pytest features to control which scenarios are run and how they are executed.
 
-**Note**: Optionally you can define ``MOLECULE_OPTS`` for passing extra parameters to
+**Note**: Optionally you can define `MOLECULE_OPTS` for passing extra parameters to
 each molecule call.
 
-Discovered tests do have molecule ``driver`` and ``platforms`` added as
+Discovered tests do have molecule `driver` and `platforms` added as
 [markers](https://doc.pytest.org/en/latest/example/markers.html), so you can selectively limit which test types to run:
 
 ```
@@ -117,32 +129,30 @@ Discovered tests do have molecule ``driver`` and ``platforms`` added as
 ```
 
 If the molecule scenario does not contain information about the driver, the
-test associated with it gets a ``no_driver`` mark.
+test associated with it gets a `no_driver` mark.
 
 Please note that at this moment molecule will run the entire scenario if the
-markers are platforms, this is not *yet* a way to limit which platforms are
+markers are platforms, this is not _yet_ a way to limit which platforms are
 executed inside a specific scenario.
 
-All tests are added the ``molecule`` marker.
+All tests are added the `molecule` marker.
 
 This plugin also adds a new pytest option named
-``--molecule-unavailable-driver=skip`` which can be used to tell it what to do
-when molecule drivers are not loading. Current default is ``None`` but you
-can choose marks like ``skip`` or ``xfail``.
+`--molecule-unavailable-driver=skip` which can be used to tell it what to do
+when molecule drivers are not loading. Current default is `None` but you
+can choose marks like `skip` or `xfail`.
 
-The plugin adds ``--skip-no-git-change`` option which an be used to skip tests
-on unchanged roles according to ``git diff`` result and thus can only be used
+The plugin adds `--skip-no-git-change` option which an be used to skip tests
+on unchanged roles according to `git diff` result and thus can only be used
 only when running pytest inside a git repository. It takes one argument and old
 refspec used as a reference. For instance calling:
-``pytest --skip-no-git-change HEAD^`` will result in molecule of roles that
+`pytest --skip-no-git-change HEAD^` will result in molecule of roles that
 weren't changed in the last commit being skipped.
 
+## Using xfail and skip markers
 
-Using xfail and skip markers
-----------------------------
-
-If you need to skip or ignore a particular scenario, just add either ``xfail``
-or ``skip`` to markers list inside its config file.
+If you need to skip or ignore a particular scenario, just add either `xfail`
+or `skip` to markers list inside its config file.
 
 ```
     markers:
@@ -182,6 +192,7 @@ The `molecule_scenario` fixture provides parameterized molecule scenarios discov
 Run molecule with the `--molecule` command line parameter to inject each molecule directory found in the current working directory. Each scenario will be injected as an external test in the the tests available for pytest. Due to the nature of this approach, the molecule scenarios are not represented as python tests and may not show in the IDE's pytest test tree.
 
 ## Ansible Integration for Pytest Tests
+
 The `ansible_module`, `ansible_adhoc`, `localhost`, and `ansible_facts` fixtures are provided to help you integrate Ansible functionalities into your pytest tests. These fixtures allow you to interact with Ansible modules, run commands on localhost, fetch Ansible facts, and more.
 
 ## Fixtures and helpers for use in tests


### PR DESCRIPTION
Update docs to reflect `pytest-ansible-unit` and `pytest-molecule` capabilities 
