### PR TITLE
Add tests for inventory

### DIFF
--- a/.config/requirements.txt
+++ b/.config/requirements.txt
@@ -33,7 +33,7 @@ pyyaml==6.0.1
 referencing==0.30.2
 resolvelib==1.0.1
 rich==13.5.2
-rpds-py==0.10.3
+rpds-py==0.10.2
 subprocess-tee==0.4.1
 tomli==2.0.1
 typing-extensions==4.7.1

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test
 
 ## Molecule Scenario Integration
 
-This functionality assists in running Molecule `scenarios` using `pytest`. It enables pytest discovery of all `molecule.yml` files inside the codebase and runs them as pytest tests. It allows you to include Molecule scenarios as part of your pytest test suite, allowing you to thoroughly test your Ansible roles and playbooks across different scenarios and environments. 
+This functionality assists in running Molecule `scenarios` using `pytest`. It enables pytest discovery of all `molecule.yml` files inside the codebase and runs them as pytest tests. It allows you to include Molecule scenarios as part of your pytest test suite, allowing you to thoroughly test your Ansible roles and playbooks across different scenarios and environments.
 
 ## Running molecule scenarios using pytest
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,63 @@ HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test
 
 ## Molecule Scenario Integration
 
-This functionality assists in running Molecule `scenarios` using `pytest`. It enables pytest discovery of all `molecule.yml` files inside the codebase and runs them as pytest tests. It allows you to include Molecule scenarios as part of your pytest test suite, allowing you to thoroughly test your Ansible roles and playbooks across different scenarios and environments.
+The `pytest-molecule` plugin enables pytest discovery of all `molecule.yml` files inside the codebase and runs them as pytest tests. It allows you to include Molecule scenarios as part of your pytest test suite, allowing you to thoroughly test your Ansible roles and playbooks across different scenarios and environments. Once you install `pytest-ansible`, you should be able to just run `pytest` to execute Molecule on all roles and scenarios.
+
+To run Molecule scenarios using pytest, follow these steps:
+
+1. Install the `pytest-ansible` plugin using pip:
+
+```
+pip install pytest-ansible
+```
+
+2. Execute pytest to run Molecule scenarios: `pytest`
+3. You can use markers and other pytest features to control which scenarios are run and how they are executed.
+
+**Note**: Optionally you can define `MOLECULE_OPTS` for passing extra parameters to
+each molecule call.
+
+Discovered tests do have molecule `driver` and `platforms` added as
+[markers](https://doc.pytest.org/en/latest/example/markers.html), so you can selectively limit which test types to run:
+
+```
+    # Lists all tests that uses docker
+    $ pytest --collect-only -m docker
+
+    # Runs scenarios with platform named centos7 and delegated driver:
+    $ pytest -m delegated -m centos7
+```
+
+If the molecule scenario does not contain information about the driver, the
+test associated with it gets a `no_driver` mark.
+
+Please note that at this moment molecule will run the entire scenario if the
+markers are platforms, this is not _yet_ a way to limit which platforms are
+executed inside a specific scenario.
+
+All tests are added the `molecule` marker.
+
+This plugin also adds a new pytest option named
+`--molecule-unavailable-driver=skip` which can be used to tell it what to do
+when molecule drivers are not loading. Current default is `None` but you
+can choose marks like `skip` or `xfail`.
+
+The plugin adds `--skip-no-git-change` option which an be used to skip tests
+on unchanged roles according to `git diff` result and thus can only be used
+only when running pytest inside a git repository. It takes one argument and old
+refspec used as a reference. For instance calling:
+`pytest --skip-no-git-change HEAD^` will result in molecule of roles that
+weren't changed in the last commit being skipped.
+
+## Using xfail and skip markers
+
+If you need to skip or ignore a particular scenario, just add either `xfail`
+or `skip` to markers list inside its config file.
+
+```
+    markers:
+      - xfail  # broken scenario, pytest will run it but ignore the result
+```
 
 ## Running molecule scenarios using pytest
 

--- a/README.md
+++ b/README.md
@@ -101,63 +101,7 @@ HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test
 
 ## Molecule Scenario Integration
 
-The `pytest-molecule` plugin enables pytest discovery of all `molecule.yml` files inside the codebase and runs them as pytest tests. It allows you to include Molecule scenarios as part of your pytest test suite, allowing you to thoroughly test your Ansible roles and playbooks across different scenarios and environments. Once you install `pytest-ansible`, you should be able to just run `pytest` to execute Molecule on all roles and scenarios.
-
-To run Molecule scenarios using pytest, follow these steps:
-
-1. Install the `pytest-ansible` plugin using pip:
-
-```
-pip install pytest-ansible
-```
-
-2. Execute pytest to run Molecule scenarios: `pytest`
-3. You can use markers and other pytest features to control which scenarios are run and how they are executed.
-
-**Note**: Optionally you can define `MOLECULE_OPTS` for passing extra parameters to
-each molecule call.
-
-Discovered tests do have molecule `driver` and `platforms` added as
-[markers](https://doc.pytest.org/en/latest/example/markers.html), so you can selectively limit which test types to run:
-
-```
-    # Lists all tests that uses docker
-    $ pytest --collect-only -m docker
-
-    # Runs scenarios with platform named centos7 and delegated driver:
-    $ pytest -m delegated -m centos7
-```
-
-If the molecule scenario does not contain information about the driver, the
-test associated with it gets a `no_driver` mark.
-
-Please note that at this moment molecule will run the entire scenario if the
-markers are platforms, this is not _yet_ a way to limit which platforms are
-executed inside a specific scenario.
-
-All tests are added the `molecule` marker.
-
-This plugin also adds a new pytest option named
-`--molecule-unavailable-driver=skip` which can be used to tell it what to do
-when molecule drivers are not loading. Current default is `None` but you
-can choose marks like `skip` or `xfail`.
-
-The plugin adds `--skip-no-git-change` option which an be used to skip tests
-on unchanged roles according to `git diff` result and thus can only be used
-only when running pytest inside a git repository. It takes one argument and old
-refspec used as a reference. For instance calling:
-`pytest --skip-no-git-change HEAD^` will result in molecule of roles that
-weren't changed in the last commit being skipped.
-
-## Using xfail and skip markers
-
-If you need to skip or ignore a particular scenario, just add either `xfail`
-or `skip` to markers list inside its config file.
-
-```
-    markers:
-      - xfail  # broken scenario, pytest will run it but ignore the result
-```
+This functionality assists in running Molecule `scenarios` using `pytest`. It enables pytest discovery of all `molecule.yml` files inside the codebase and runs them as pytest tests. It allows you to include Molecule scenarios as part of your pytest test suite, allowing you to thoroughly test your Ansible roles and playbooks across different scenarios and environments. 
 
 ## Running molecule scenarios using pytest
 

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -246,7 +246,7 @@ def pytest_generate_tests(metafunc):
             raise pytest.UsageError(exception)
 
         # Return the host name as a string
-        metafunc.parametrize("ansible_host", hosts.keys())
+        metafunc.parametrize("ansible_host", iter(hosts[h] for h in hosts))
 
     if "ansible_group" in metafunc.fixturenames:
         # assert required --ansible-* parameters were used
@@ -259,15 +259,11 @@ def pytest_generate_tests(metafunc):
             )
         except ansible.errors.AnsibleError as exception:
             raise pytest.UsageError(exception)
-
-        # Fetch groups using inventory manager
-        inventory_manager = hosts.options["inventory_manager"]
-        groups = inventory_manager.list_groups()
+        groups = hosts.options["inventory_manager"].list_groups()
         extra_groups = hosts.get_extra_inventory_groups()
-
-        # Return the group names as strings
-        group_names = groups + extra_groups
-        metafunc.parametrize("ansible_group", group_names)
+        # Return the group name as a string
+        metafunc.parametrize("ansible_group", iter(hosts[g] for g in groups))
+        metafunc.parametrize("ansible_group", iter(hosts[g] for g in extra_groups))
 
     if "molecule_scenario" in metafunc.fixturenames:
         if not HAS_MOLECULE:

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -260,7 +260,7 @@ def pytest_generate_tests(metafunc):
         except ansible.errors.AnsibleError as exception:
             raise pytest.UsageError(exception)
 
-        # Fetch groups using the inventory manager
+        # Fetch groups using inventory manager
         inventory_manager = hosts.options["inventory_manager"]
         groups = inventory_manager.list_groups()
         extra_groups = hosts.get_extra_inventory_groups()

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -244,12 +244,9 @@ def pytest_generate_tests(metafunc):
             )
         except ansible.errors.AnsibleError as exception:
             raise pytest.UsageError(exception)
+
         # Return the host name as a string
-        # Return a HostManager instance where pattern=host (e.g. ansible_host.all.shell('date'))
-        # metafunc.parametrize("ansible_host", iter(plugin.initialize(config=plugin.config, pattern=h) for h in
-        #                                           hosts.keys()))
-        # Return a ModuleDispatcher instance representing `host` (e.g. ansible_host.shell('date'))
-        metafunc.parametrize("ansible_host", iter(hosts[h] for h in hosts))
+        metafunc.parametrize("ansible_host", hosts.keys())
 
     if "ansible_group" in metafunc.fixturenames:
         # assert required --ansible-* parameters were used
@@ -262,21 +259,21 @@ def pytest_generate_tests(metafunc):
             )
         except ansible.errors.AnsibleError as exception:
             raise pytest.UsageError(exception)
-        # FIXME: Eeew, this shouldn't be interfacing with `hosts.options`  # noqa: TD001, TD002, FIX001
-        # https://github.com/ansible-community/pytest-ansible/issues/151
-        groups = hosts.options["inventory_manager"].list_groups()
+
+        # Fetch groups using the inventory manager
+        inventory_manager = hosts.options["inventory_manager"]
+        groups = inventory_manager.list_groups()
         extra_groups = hosts.get_extra_inventory_groups()
-        # Return the group name as a string
-        # Return a ModuleDispatcher instance representing the group (e.g. ansible_group.shell('date'))
-        metafunc.parametrize("ansible_group", iter(hosts[g] for g in groups))
-        metafunc.parametrize("ansible_group", iter(hosts[g] for g in extra_groups))
+
+        # Return the group names as strings
+        group_names = groups + extra_groups
+        metafunc.parametrize("ansible_group", group_names)
 
     if "molecule_scenario" in metafunc.fixturenames:
         if not HAS_MOLECULE:
             pytest.exit("molecule not installed or found.")
 
         # Find all molecule scenarios not gitignored
-        # Replace this with molecule --list in the future if json output is available
         rootpath = metafunc.config.rootpath
 
         scenarios = []
@@ -311,7 +308,7 @@ def pytest_generate_tests(metafunc):
                 ),
             )
         if not scenarios:
-            pytest.exit(f"No molecule scenarions found in: {rootpath}")
+            pytest.exit(f"No molecule scenarios found in: {rootpath}")
         metafunc.parametrize(
             "molecule_scenario",
             scenarios,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,6 +1,7 @@
 from unittest import mock
+from unittest.mock import MagicMock
 
-from pytest_ansible.plugin import PyTestAnsiblePlugin
+from pytest_ansible.plugin import PyTestAnsiblePlugin, pytest_generate_tests
 
 
 class MockItem:
@@ -24,6 +25,80 @@ class MockConfig:
 
     def getoption(self, option_name):
         return self.options.get(option_name)
+
+    def __init__(self):
+        self.options = {
+            "ansible_host_pattern": "localhost",
+            "ansible_inventory": "/etc/ansible/hosts",
+        }
+
+
+class MockPluginManager:
+    """Mock class for pluginmanager object"""
+
+    def getplugin(self, name):
+        return MagicMock()
+
+
+class MockMetafunc:
+    """Mock class for metafunc object"""
+
+    def __init__(self, fixturenames):
+        self.fixturenames = fixturenames
+        self.config = MockConfig()
+        self.parametrize = MagicMock()
+
+
+def test_pytest_generate_tests_with_ansible_host():
+    metafunc = MagicMock()
+    metafunc.fixturenames = ["ansible_host"]
+    metafunc.config = MagicMock()
+
+    # Mock config values
+    metafunc.config.getoption.side_effect = {
+        "ansible_host_pattern": "localhost",
+        "ansible_inventory": "/etc/ansible/hosts",
+    }.get
+
+    plugin = PyTestAnsiblePlugin(metafunc.config)
+
+    # Mock Ansible host initialization
+    host = MagicMock()
+    host.name = "localhost"
+    plugin.initialize = MagicMock(return_value={"localhost": host})
+
+    pytest_generate_tests(metafunc)
+
+    assert metafunc.parametrize.call_count == 1
+
+
+def test_pytest_generate_tests_with_ansible_group():
+    metafunc = MagicMock()
+    metafunc.fixturenames = ["ansible_group"]
+    config = MagicMock()
+    config.pluginmanager = MagicMock()
+    metafunc.config = config
+
+    plugin = PyTestAnsiblePlugin(metafunc.config)
+
+    # Mock Ansible host initialization
+    host1 = MagicMock()
+    host1.name = "host1"
+    group1 = MagicMock()
+    group1.name = "group1"
+    host1.groups = [group1]
+
+    host2 = MagicMock()
+    host2.name = "host2"
+    group2 = MagicMock()
+    group2.name = "group2"
+    host2.groups = [group2]
+
+    plugin.initialize = MagicMock(return_value={"host1": host1, "host2": host2})
+
+    pytest_generate_tests(metafunc)
+
+    assert metafunc.parametrize.call_count == 2  # Called twice for ansible_group
 
 
 def test_pytest_collection_modifyitems_with_marker():


### PR DESCRIPTION
closes #151 

- In the `ansible_host` section, I simplified the parameterization of `ansible_host` by directly using the host names as `keys `from the hosts dictionary.

- In the `ansible_group` section, extracted the group names using the `inventory_manager` instead of accessing `hosts.options["inventory_manager"] `directly.